### PR TITLE
argParser clean up

### DIFF
--- a/src/utils/argParser.ts
+++ b/src/utils/argParser.ts
@@ -10,21 +10,7 @@ export const argParser = (
 ): string[] => {
   let cursorOne: number, cursorTwo: number;
   const args = [];
-  cursorOne = 0;
-
-  if (argString[cursorOne] !== prefix) {
-    //not command
-  }
-
-  cursorOne++;
-  cursorTwo = cursorOne;
-  //don't need to check for block argument on command portion
-  while (argString[cursorTwo] !== " ") {
-    cursorTwo++;
-  }
-
-  //first entry in the array is the command
-  args.push(argString.substring(cursorOne, cursorTwo));
+  cursorTwo = prefix.length - 1;
 
   for (cursorOne = cursorTwo + 1; cursorOne < argString.length; cursorOne = cursorTwo + 1) {
     //tolerate multiple spaces between arguments


### PR DESCRIPTION
This change allows prefix strings to be larger than 1 character. I also removed some redundant code as well as now treating the command portion of the string the same way as the arguments after are treated. This will mean that if the command has spaces before it, it will still work and if wrapped by parentheses that are configured, they will also be ignored.

It's possible we want the command to never have preceding spaces and/or not be wrapped by the configured parentheses so looking for feedback to if these changes are wanted.