### PR TITLE
Parenthesis config, and snowflake matching

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
     "prettier/@typescript-eslint"
   ],
   "env": {
-    "browser": true,
+    "node": true,
     "es6": true
   },
   "plugins": ["@typescript-eslint", "prettier"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,6 @@
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/unbound-method": "off",
     "@typescript-eslint/no-var-requires": "off"
   },
   "overrides": [

--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
     "@types/mocha": "^8.0.3",
     "@types/node": "^14.11.2",
     "@types/node-schedule": "^1.3.0",
-    "@types/sinon": "^9.0.5",
-    "@typescript-eslint/eslint-plugin": "^4.1.1",
-    "@typescript-eslint/parser": "^4.1.1",
+    "@types/sinon": "^9.0.6",
+    "@typescript-eslint/eslint-plugin": "^4.2.0",
+    "@typescript-eslint/parser": "^4.2.0",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
-    "eslint": "^7.9.0",
-    "eslint-config-prettier": "^6.11.0",
+    "eslint": "^7.10.0",
+    "eslint-config-prettier": "^6.12.0",
     "eslint-plugin-prettier": "^3.1.4",
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "discord.js": "^12.3.1",
-    "rxjs": "^6.6.3",
-    "node-schedule": "^1.3.2"
+    "node-schedule": "^1.3.2",
+    "rxjs": "^6.6.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,20 +1,20 @@
 dependencies:
   discord.js: 12.3.1
-  rxjs: 6.6.3
   node-schedule: 1.3.2
+  rxjs: 6.6.3
 devDependencies:
   '@types/chai': 4.2.12
   '@types/mocha': 8.0.3
   '@types/node': 14.11.2
   '@types/node-schedule': 1.3.0
-  '@types/sinon': 9.0.5
-  '@typescript-eslint/eslint-plugin': 4.2.0_0d6e027e5aced4d334a249431fe3b66e
-  '@typescript-eslint/parser': 4.2.0_eslint@7.9.0+typescript@4.0.3
+  '@types/sinon': 9.0.6
+  '@typescript-eslint/eslint-plugin': 4.2.0_01bb2a57a800356006ca47d0aed8d623
+  '@typescript-eslint/parser': 4.2.0_eslint@7.10.0+typescript@4.0.3
   chai: 4.2.0
   cross-env: 7.0.2
-  eslint: 7.9.0
-  eslint-config-prettier: 6.11.0_eslint@7.9.0
-  eslint-plugin-prettier: 3.1.4_eslint@7.9.0+prettier@2.1.2
+  eslint: 7.10.0
+  eslint-config-prettier: 6.12.0_eslint@7.10.0
+  eslint-plugin-prettier: 3.1.4_eslint@7.10.0+prettier@2.1.2
   mocha: 8.1.3
   nyc: 15.1.0
   prettier: 2.1.2
@@ -313,23 +313,23 @@ packages:
     dev: true
     resolution:
       integrity: sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==
-  /@types/sinon/9.0.5:
+  /@types/sinon/9.0.6:
     dependencies:
-      '@types/sinonjs__fake-timers': 6.0.1
+      '@types/sinonjs__fake-timers': 6.0.2
     dev: true
     resolution:
-      integrity: sha512-4CnkGdM/5/FXDGqL32JQ1ttVrGvhOoesLLF7VnTh4KdjK5N5VQOtxaylFqqTjnHx55MnD9O02Nbk5c1ELC8wlQ==
-  /@types/sinonjs__fake-timers/6.0.1:
+      integrity: sha512-j3GK0fiHgn8fe7sqOpInMjm0A2Tary1NBZ8gbI/sZ0C0JxYeO+nh8H0/pW/0l94vNWcH1FnZOZu/cOvIfNZTrg==
+  /@types/sinonjs__fake-timers/6.0.2:
     dev: true
     resolution:
-      integrity: sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==
-  /@typescript-eslint/eslint-plugin/4.2.0_0d6e027e5aced4d334a249431fe3b66e:
+      integrity: sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==
+  /@typescript-eslint/eslint-plugin/4.2.0_01bb2a57a800356006ca47d0aed8d623:
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.2.0_eslint@7.9.0+typescript@4.0.3
-      '@typescript-eslint/parser': 4.2.0_eslint@7.9.0+typescript@4.0.3
+      '@typescript-eslint/experimental-utils': 4.2.0_eslint@7.10.0+typescript@4.0.3
+      '@typescript-eslint/parser': 4.2.0_eslint@7.10.0+typescript@4.0.3
       '@typescript-eslint/scope-manager': 4.2.0
       debug: 4.2.0
-      eslint: 7.9.0
+      eslint: 7.10.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.1.0
       semver: 7.3.2
@@ -347,13 +347,13 @@ packages:
         optional: true
     resolution:
       integrity: sha512-zBNRkzvLSwo6y5TG0DVcmshZIYBHKtmzD4N+LYnfTFpzc4bc79o8jNRSb728WV7A4Cegbs+MV5IRAj8BKBgOVQ==
-  /@typescript-eslint/experimental-utils/4.2.0_eslint@7.9.0+typescript@4.0.3:
+  /@typescript-eslint/experimental-utils/4.2.0_eslint@7.10.0+typescript@4.0.3:
     dependencies:
       '@types/json-schema': 7.0.6
       '@typescript-eslint/scope-manager': 4.2.0
       '@typescript-eslint/types': 4.2.0
       '@typescript-eslint/typescript-estree': 4.2.0_typescript@4.0.3
-      eslint: 7.9.0
+      eslint: 7.10.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
     dev: true
@@ -364,13 +364,13 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-5BBj6BjgHEndBaQQpUVzRIPERz03LBc0MCQkHwUaH044FJFL08SwWv/sQftk7gf0ShZ2xZysz0LTwCwNt4Xu3w==
-  /@typescript-eslint/parser/4.2.0_eslint@7.9.0+typescript@4.0.3:
+  /@typescript-eslint/parser/4.2.0_eslint@7.10.0+typescript@4.0.3:
     dependencies:
       '@typescript-eslint/scope-manager': 4.2.0
       '@typescript-eslint/types': 4.2.0
       '@typescript-eslint/typescript-estree': 4.2.0_typescript@4.0.3
       debug: 4.2.0
-      eslint: 7.9.0
+      eslint: 7.10.0
       typescript: 4.0.3
     dev: true
     engines:
@@ -947,19 +947,19 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
-  /eslint-config-prettier/6.11.0_eslint@7.9.0:
+  /eslint-config-prettier/6.12.0_eslint@7.10.0:
     dependencies:
-      eslint: 7.9.0
+      eslint: 7.10.0
       get-stdin: 6.0.0
     dev: true
     hasBin: true
     peerDependencies:
       eslint: '>=3.14.1'
     resolution:
-      integrity: sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==
-  /eslint-plugin-prettier/3.1.4_eslint@7.9.0+prettier@2.1.2:
+      integrity: sha512-9jWPlFlgNwRUYVoujvWTQ1aMO8o6648r+K7qU7K5Jmkbyqav1fuEZC0COYpGBxyiAJb65Ra9hrmFx19xRGwXWw==
+  /eslint-plugin-prettier/3.1.4_eslint@7.10.0+prettier@2.1.2:
     dependencies:
-      eslint: 7.9.0
+      eslint: 7.10.0
       prettier: 2.1.2
       prettier-linter-helpers: 1.0.0
     dev: true
@@ -999,7 +999,7 @@ packages:
       node: '>=10'
     resolution:
       integrity: sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
-  /eslint/7.9.0:
+  /eslint/7.10.0:
     dependencies:
       '@babel/code-frame': 7.10.4
       '@eslint/eslintrc': 0.1.3
@@ -1043,7 +1043,7 @@ packages:
       node: ^10.12.0 || >=12.0.0
     hasBin: true
     resolution:
-      integrity: sha512-V6QyhX21+uXp4T+3nrNfI3hQNBDa/P8ga7LoQOenwrlEFXrEnUEE+ok1dMtaS3b6rmLXhT1TkTIsG75HMLbknA==
+      integrity: sha512-BDVffmqWl7JJXqCjAK6lWtcQThZB/aP1HXSH1JKwGwv0LQEdvpR7qzNrUT487RM39B5goWuboFad5ovMBmD8yA==
   /espree/7.3.0:
     dependencies:
       acorn: 7.4.0
@@ -2779,14 +2779,14 @@ specifiers:
   '@types/mocha': ^8.0.3
   '@types/node': ^14.11.2
   '@types/node-schedule': ^1.3.0
-  '@types/sinon': ^9.0.5
-  '@typescript-eslint/eslint-plugin': ^4.1.1
-  '@typescript-eslint/parser': ^4.1.1
+  '@types/sinon': ^9.0.6
+  '@typescript-eslint/eslint-plugin': ^4.2.0
+  '@typescript-eslint/parser': ^4.2.0
   chai: ^4.2.0
   cross-env: ^7.0.2
   discord.js: ^12.3.1
-  eslint: ^7.9.0
-  eslint-config-prettier: ^6.11.0
+  eslint: ^7.10.0
+  eslint-config-prettier: ^6.12.0
   eslint-plugin-prettier: ^3.1.4
   mocha: ^8.1.3
   node-schedule: ^1.3.2

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -1,11 +1,10 @@
-import { Message } from "discord.js";
 import type { Command } from "./type";
 
 export const ping: Command = {
   name: "ping",
   description: "Ping!",
   definition: "ping",
-  async execute(message: Message): Promise<void> {
+  async execute(message) {
     await message.channel.send("Pong");
   },
 };

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -1,5 +1,4 @@
 import type { Command } from "./type";
-import { Message } from "discord.js";
 import { scheduleJob } from "node-schedule";
 
 const days: Record<string, number> = {
@@ -16,27 +15,24 @@ export const schedule: Command = {
   name: "schedule",
   description: "Schedule reoccuring messages",
   definition: "schedule :day :time *",
-  async execute(
-    { channel, reply }: Message,
-    { day, time, message }: Record<string, string>
-  ): Promise<void> {
+  async execute(command, { day, time, message }): Promise<void> {
     if (day in days === false) {
-      await reply("Invalid day argument. Spell full name of day");
+      await command.reply("Invalid day argument. Spell full name of day");
       return;
     }
 
     const timeRegex = /^([01]?[0-9]|2[0-3]):[0-5][0-9]$/;
     if (!timeRegex.exec(time)) {
-      await reply("Invalid time argument (24 hour time eg 13:30)");
+      await command.reply("Invalid time argument (24 hour time eg 13:30)");
       return;
     }
 
     const [hour, minute] = time.split(":");
 
     scheduleJob({ minute, hour, dayOfWeek: days[day] }, () => {
-      void channel.send(message);
+      void command.channel.send(message);
     });
 
-    await channel.send("Message scheduled");
+    await command.channel.send("Message scheduled");
   },
 };

--- a/src/handler/types.ts
+++ b/src/handler/types.ts
@@ -1,8 +1,9 @@
 import { Message } from "discord.js";
 
 export interface Config {
-  token: string;
-  prefix: string;
+  readonly token: string;
+  readonly prefix: string;
+  readonly parenthesis: [string, string];
 }
 
 export interface HandlerEvent {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,12 @@
+import { readFileSync } from "fs";
 import { Client } from "discord.js";
 import * as commands from "./commands";
 import { Config, createMessageStream, handleCommand } from "./handler";
 import { createCommandMatcher } from "./matcher/createMatcher";
 
-/* eslint-disable-next-line */
-const config = require("../config.json") as Config;
-
+const config = JSON.parse(readFileSync("./config.json", "utf-8")) as Config;
 const client = new Client();
-const commandMatcher = createCommandMatcher(config.prefix, commands);
-
-const eventStream = createMessageStream(config, client, commandMatcher);
+const eventStream = createMessageStream(config, client, createCommandMatcher(config, commands));
 
 eventStream.subscribe({
   next: handleCommand,

--- a/src/matcher/createMatcher.ts
+++ b/src/matcher/createMatcher.ts
@@ -1,6 +1,7 @@
 import { Command } from "../commands/type";
 import { CommandMatcher } from "./types";
 import { createCommandDefinition, createErrorDefinition } from "./createDefinitions";
+import { Config } from "../handler";
 
 const extractMatchedArguments = (matches: RegExpExecArray, args: string[]) =>
   args.reduce<Record<string, string>>((matched, arg, index) => {
@@ -24,13 +25,13 @@ const extractError = (content: RegExpExecArray | null) => {
  * @param commands A record of all available commands
  */
 export const createCommandMatcher = (
-  prefix: string,
+  config: Config,
   commands: Record<string, Command>
 ): CommandMatcher => {
   const indexedCommands = Object.values(commands).map((command) =>
-    createCommandDefinition(prefix, command)
+    createCommandDefinition(config, command)
   );
-  const errorCheck = createErrorDefinition(prefix);
+  const errorCheck = createErrorDefinition(config.prefix);
   return (message) => {
     for (const { command, match, args } of indexedCommands) {
       const matchedCommand = match.exec(message.content);

--- a/test/matcher/createDefinitions.spec.ts
+++ b/test/matcher/createDefinitions.spec.ts
@@ -1,25 +1,30 @@
 import { expect } from "chai";
 import type { Command } from "../../src/commands/type";
+import { Config } from "../../src/handler";
 import {
   createCommandDefinition,
   createErrorDefinition,
 } from "../../src/matcher/createDefinitions";
 
 describe("createDefinitions.ts", () => {
+  const config = {
+    prefix: "!",
+    parenthesis: ['"', '"'],
+  } as Config;
   describe("createCommandDefinition", () => {
     it("should create a working regex match", () => {
-      const definition = createCommandDefinition("!", {
-        definition: "ping :id @name *",
+      const definition = createCommandDefinition(config, {
+        definition: 'ping :id @name "paren *',
       } as Command);
       expect(definition.match.toString()).to.equal(
-        '/^!ping\\s+(\\S+)\\s+"(.+)"\\s+([\\s\\S]*)\\s*$/'
+        '/^!ping\\s+(\\S+)\\s+(<@(?:!|&)\\d+>)\\s+"([^""\\n]+)"\\s+([\\s\\S]*)\\s*$/'
       );
     });
     it("should provide all the arguments in a definition", () => {
-      const definition = createCommandDefinition("!", {
-        definition: "ping :id @name *",
+      const definition = createCommandDefinition(config, {
+        definition: 'ping :id @name "paren *',
       } as Command);
-      expect(definition.args).to.deep.equal(["id", "name", "message"]);
+      expect(definition.args).to.deep.equal(["id", "name", "paren", "message"]);
     });
   });
   describe("createErrorDefinition", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "moduleResolution": "node",
     "target": "es2019",
     "rootDir": "./",
-    "stripInternal": true,
+    "stripInternal": true
   },
   "include": ["./src/**/*", "./test/**/*"]
 }


### PR DESCRIPTION
Adds the ability to configure parenthesis in the config file, taking the format of a tuple for left/right parenthesis. So `["\"", "\""]` will assume that parenthesis values are wrapped in `""` like `"a block of text"`. Different parenthesis can then be configured in the config.json file. Parenthesis values now are defined in the `"name` format.

In this PR is also the `@name` format, originally the parenthesis format but now for matching snowflake types for users/roles. Won't work with `@here` and the like.

resolves #9 