### PR TITLE
Color command

### DIFF
--- a/src/commands/color.ts
+++ b/src/commands/color.ts
@@ -1,0 +1,28 @@
+import type { Command } from "./type";
+
+export const color: Command = {
+  name: "color",
+  description: "Sets color of member in the guild",
+  definition: "color :colorHex",
+  async execute({ message, args }): Promise<void> {
+    const hex = args["colorHex"];
+    if (!isValidHex(hex)) {
+      await message.reply("Invalid hex value");
+      return;
+    }
+
+    if (!message.guild) {
+      await message.reply("Must be used in a guild channel");
+      return;
+    }
+  },
+};
+
+export const isValidHex = (hex: string): boolean => {
+  const hexRegex = /^#[0-9a-f]{6}$/;
+  if (hexRegex.exec(hex)) {
+    return true;
+  } else {
+    return false;
+  }
+};

--- a/src/commands/color.ts
+++ b/src/commands/color.ts
@@ -7,6 +7,8 @@ export const color: Command = {
   name: "color",
   description: "Sets color of member in the guild",
   definition: "color :colorHex",
+  help:
+    "use !color <hex>\n<hex> #ffffff hexadeciaml format. Google color picker and most will give you this value",
   async execute({ message, args }): Promise<void> {
     const hex = args["colorHex"];
     if (!isValidHex(hex)) {

--- a/src/commands/color.ts
+++ b/src/commands/color.ts
@@ -24,8 +24,7 @@ export const color: Command = {
     const roles = await message.guild.roles.fetch();
 
     if (!roles) {
-      await message.reply("Role fetch failed");
-      return;
+      throw new Error("Role fetch failed");
     }
     //check if role with color already exists
     const role = roles.cache.find((role) => role.name === hex);
@@ -36,8 +35,7 @@ export const color: Command = {
     });
 
     if (!guildMember) {
-      await message.reply("Failed to get guild member");
-      return;
+      throw new Error("GuildMember find failed");
     }
 
     await removePreviousColor(guildMember, hexRegex);
@@ -72,8 +70,7 @@ export const removePreviousColor = async (
   const role = user.roles.cache.find((role) => nameRegex.exec(role.name) !== null);
   if (role) {
     await user.roles.remove(role);
-    if (role) {
-      role.members.size === 0;
+    if (role.members.size === 0) {
       await role.delete();
     }
     return true;

--- a/src/commands/color.ts
+++ b/src/commands/color.ts
@@ -1,4 +1,7 @@
 import type { Command } from "./type";
+import { GuildMember } from "discord.js";
+
+const hexRegex = /^#[0-9a-f]{6}$/;
 
 export const color: Command = {
   name: "color",
@@ -15,12 +18,62 @@ export const color: Command = {
       await message.reply("Must be used in a guild channel");
       return;
     }
+
+    const roles = await message.guild.roles.fetch();
+
+    if (!roles) {
+      await message.reply("Role fetch failed");
+      return;
+    }
+    //check if role with color already exists
+    const role = roles.cache.find((role) => role.name === hex);
+
+    const { author, guild } = message;
+    const guildMember = guild.members.cache.find((member) => {
+      return member.user.id === author.id;
+    });
+
+    if (!guildMember) {
+      await message.reply("Failed to get guild member");
+      return;
+    }
+
+    await removePreviousColor(guildMember, hexRegex);
+
+    if (role) {
+      await guildMember.roles.add(role);
+    } else {
+      const newRole = await guild.roles.create({
+        data: {
+          name: hex,
+          color: hex,
+        },
+      });
+      await guildMember.roles.add(newRole);
+    }
+    await message.reply("New color set");
   },
 };
 
 export const isValidHex = (hex: string): boolean => {
-  const hexRegex = /^#[0-9a-f]{6}$/;
   if (hexRegex.exec(hex)) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
+export const removePreviousColor = async (
+  user: GuildMember,
+  nameRegex: RegExp
+): Promise<boolean> => {
+  const role = user.roles.cache.find((role) => nameRegex.exec(role.name) !== null);
+  if (role) {
+    await user.roles.remove(role);
+    if (role) {
+      role.members.size === 0;
+      await role.delete();
+    }
     return true;
   } else {
     return false;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,5 +3,6 @@ import { schedule } from "./schedule";
 import { ping } from "./ping";
 import { help } from "./help";
 import { Command } from "./type";
+import { color } from "./color";
 
-export const commands: Command[] = [schedule, ping, commandsList, help];
+export const commands: Command[] = [schedule, ping, commandsList, color, help];

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -2,5 +2,6 @@ import { commandsList } from "./commandsList";
 import { schedule } from "./schedule";
 import { ping } from "./ping";
 import { Command } from "./type";
+import { color } from "./color";
 
-export const commands: Command[] = [schedule, ping, commandsList];
+export const commands: Command[] = [schedule, ping, commandsList, color];

--- a/test/commands/color.spec.ts
+++ b/test/commands/color.spec.ts
@@ -1,7 +1,7 @@
-import { color, isValidHex } from "../../src/commands/color";
+import { color, isValidHex, removePreviousColor } from "../../src/commands/color";
 import { expect } from "chai";
-import { spy } from "sinon";
-import { Message } from "discord.js";
+import { spy, fake } from "sinon";
+import { Message, Collection, SnowflakeUtil, GuildMember, Snowflake, Role } from "discord.js";
 import { MatchedCommand } from "../../src/matcher/types";
 
 describe("color commands", () => {
@@ -15,9 +15,71 @@ describe("color commands", () => {
     });
   });
 
+  describe("removePreviousColor function", () => {
+    const hexRegex = /^#[0-9a-f]{6}$/;
+    const removeSpy = spy();
+    const deleteSpy = spy();
+    beforeEach(() => {
+      removeSpy.resetHistory();
+      deleteSpy.resetHistory();
+    });
+    it("should return true after removing role", async () => {
+      const cache = new Collection();
+      const members = {
+        size: 0,
+      };
+      cache.set(SnowflakeUtil.generate(), { name: "#0f0f0f", delete: deleteSpy, members: members });
+      const user: unknown = {
+        roles: {
+          cache: cache,
+          remove: removeSpy,
+        },
+      };
+      const result = await removePreviousColor(user as GuildMember, hexRegex);
+      expect(result).to.be.true;
+    });
+
+    it("should return false when no color role exists", async () => {
+      const cache = new Collection();
+      const removeSpy = spy();
+      cache.set(SnowflakeUtil.generate(), { name: "happy" });
+      const user: unknown = {
+        roles: {
+          cache: cache,
+          remove: removeSpy,
+        },
+      };
+      const result = await removePreviousColor(user as GuildMember, hexRegex);
+      expect(result).to.be.false;
+    });
+
+    it("should call delete if role has 0 members on it", async () => {
+      const cache = new Collection();
+      const members = {
+        size: 0,
+      };
+      cache.set(SnowflakeUtil.generate(), { name: "#0f0f0f", delete: deleteSpy, members: members });
+      const user: unknown = {
+        roles: {
+          cache: cache,
+          remove: removeSpy,
+        },
+      };
+      await removePreviousColor(user as GuildMember, hexRegex);
+      expect(deleteSpy.called).to.be.true;
+    });
+  });
+
   describe("execute", () => {
     const replySpy = spy();
-    beforeEach(() => replySpy.resetHistory());
+    const addSpy = spy();
+    const createSpy = spy();
+
+    beforeEach(() => {
+      replySpy.resetHistory();
+      addSpy.resetHistory();
+      createSpy.resetHistory();
+    });
     it("should reject invalid hex argument", async () => {
       const args: Record<string, string> = { colorHex: "#0g0g0g" };
       const message: unknown = { reply: replySpy };
@@ -36,6 +98,56 @@ describe("color commands", () => {
         args,
       } as MatchedCommand);
       expect(replySpy.firstCall.args[0]).to.be.eql("Must be used in a guild channel");
+    });
+
+    const cache = new Collection<Snowflake, Role>();
+    cache.set(SnowflakeUtil.generate(), { name: "ehawjkhejkhe" } as Role);
+    const fetchFake = fake.returns({ cache: cache });
+
+    const findFake = fake.returns({
+      roles: {
+        add: addSpy,
+        cache: {
+          find: fake(),
+        },
+      },
+    });
+
+    const guild: unknown = {
+      roles: {
+        fetch: fetchFake,
+        create: createSpy,
+      },
+      members: {
+        cache: {
+          find: findFake,
+        },
+      },
+    };
+
+    it("should call be successful when given good hex value", async () => {
+      const args: Record<string, string> = {
+        colorHex: "#000000",
+      };
+      const message: unknown = {
+        guild: guild,
+        reply: replySpy,
+      };
+      await color.execute({ message: message as Message, args: args } as MatchedCommand);
+      expect(replySpy.firstCall.args[0]).to.be.eql("New color set");
+    });
+
+    it("should call add role function when given good values", async () => {
+      const args: Record<string, string> = {
+        colorHex: "#0f0f0f",
+      };
+
+      const message: unknown = {
+        guild: guild,
+        reply: replySpy,
+      };
+      await color.execute({ message: message as Message, args: args } as MatchedCommand);
+      expect(addSpy.called).to.be.true;
     });
   });
 });

--- a/test/commands/color.spec.ts
+++ b/test/commands/color.spec.ts
@@ -1,0 +1,41 @@
+import { color, isValidHex } from "../../src/commands/color";
+import { expect } from "chai";
+import { spy } from "sinon";
+import { Message } from "discord.js";
+import { MatchedCommand } from "../../src/matcher/types";
+
+describe("color commands", () => {
+  describe("validation", () => {
+    it("should reject invalid hex color value", () => {
+      expect(isValidHex("#0ghh7i")).to.be.false;
+    });
+
+    it("should accept valid hex color value", () => {
+      expect(isValidHex("#000000")).to.be.true;
+    });
+  });
+
+  describe("execute", () => {
+    const replySpy = spy();
+    beforeEach(() => replySpy.resetHistory());
+    it("should reject invalid hex argument", async () => {
+      const args: Record<string, string> = { colorHex: "#0g0g0g" };
+      const message: unknown = { reply: replySpy };
+      await color.execute({
+        message: message as Message,
+        args,
+      } as MatchedCommand);
+      expect(replySpy.firstCall.args[0]).to.be.eql("Invalid hex value");
+    });
+
+    it("should reject message not posted in a guild channel", async () => {
+      const args: Record<string, string> = { colorHex: "#000000" };
+      const message: unknown = { reply: replySpy, guild: null };
+      await color.execute({
+        message: message as Message,
+        args,
+      } as MatchedCommand);
+      expect(replySpy.firstCall.args[0]).to.be.eql("Must be used in a guild channel");
+    });
+  });
+});

--- a/test/commands/color.spec.ts
+++ b/test/commands/color.spec.ts
@@ -36,7 +36,23 @@ describe("color commands", () => {
         },
       };
       const result = await removePreviousColor(user as GuildMember, hexRegex);
-      expect(result).to.be.true;
+      expect(result && removeSpy.called).to.be.true;
+    });
+
+    it("should not delete role if size is greater than 0", async () => {
+      const cache = new Collection();
+      const members = {
+        size: 2,
+      };
+      cache.set(SnowflakeUtil.generate(), { name: "#0f0f0f", delete: deleteSpy, members: members });
+      const user: unknown = {
+        roles: {
+          cache: cache,
+          remove: removeSpy,
+        },
+      };
+      const result = await removePreviousColor(user as GuildMember, hexRegex);
+      expect(result && !deleteSpy.called).to.be.true;
     });
 
     it("should return false when no color role exists", async () => {


### PR DESCRIPTION
Initial pass at the color command. The current implementation takes a hex colour value from the user. With this value, it will check to see if a role of the same colour already exists, if not, it will create a new one then add the user to that role.

It will also check to see if the user already had a colour role. If the user does, it will remove it, check the number of people using that role and if it is 0, will delete the role. This is done to combat the fact that this implementation will end up using many roles so deleting the ones not in use will help clear up some of the role spam.

