### PR TITLE
cancel functionality added to Scheduler

### DIFF
--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -4,11 +4,11 @@ import { validateDay, validateTime, days, isTextChannel } from "./helpers/schedu
 export const schedule: Command = {
   name: "schedule",
   description: "Schedule reoccuring messages",
-  definition: "schedule :day :time :channelStr *",
+  definition: "schedule :name :day :time :channelStr *",
   help:
-    "use !schedule <day> <time> <channel> <message>\n<day> should be spelt with full name and capital first letter\n<time> ##:## 24 hour format\n<channel>name as appears of channel\n<message>rest of command should just be your message",
+    "use !schedule <name> <day> <time> <channel> <message>\n<name> is used for cancelling the message, must not have spaces in it\n<day> should be spelt with full name and capital first letter\n<time> ##:## 24 hour format\n<channel>name as appears of channel\n<message>rest of command should just be your message",
   async execute({ message: command, args, services }): Promise<void> {
-    const { day, time, channelStr, message } = args;
+    const { name, day, time, channelStr, message } = args;
     if (!validateDay(day)) {
       await command.reply("Invalid day argument. Day must be spelt in full");
       return;
@@ -22,6 +22,10 @@ export const schedule: Command = {
     if (!isTextChannel(command.channel)) {
       await command.reply("Can only be used in a guild channel");
       return;
+    }
+
+    if (services.scheduler.has(name)) {
+      await command.reply("name already in use");
     }
 
     const { guild } = command.channel;
@@ -40,6 +44,7 @@ export const schedule: Command = {
     const [hour, minute] = time.split(":");
 
     services.scheduler.schedule(
+      name,
       { minute, hour, dayOfWeek: days[day] },
       { content: message },
       targetChannel

--- a/src/services/schedule.ts
+++ b/src/services/schedule.ts
@@ -18,9 +18,7 @@ export class Scheduler {
   jobStore = new Map<string, Job>();
   scheduleJob = scheduleJob;
 
-  constructor(private client: Client) {
-    this.client = client;
-  }
+  constructor(private client: Client) {}
 
   schedule(name: string, params: JobParams, message: MessageInfo, target?: TextChannel): void {
     let job;

--- a/src/services/schedule.ts
+++ b/src/services/schedule.ts
@@ -15,12 +15,11 @@ export interface MessageInfo {
 }
 
 export class Scheduler {
-  jobStore: Map<string, Job>;
+  jobStore = new Map<string, Job>();
   scheduleJob = scheduleJob;
 
   constructor(private client: Client) {
     this.client = client;
-    this.jobStore = new Map<string, Job>();
   }
 
   schedule(name: string, params: JobParams, message: MessageInfo, target?: TextChannel): void {

--- a/test/commands/schedule.spec.ts
+++ b/test/commands/schedule.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { validateDay, validateTime } from "../../src/commands/helpers/scheduleValidators";
 import type { MatchedCommand } from "../../src/matcher";
-import { spy } from "sinon";
+import { fake, spy } from "sinon";
 import { Message, Collection, Snowflake, SnowflakeUtil, GuildChannel } from "discord.js";
 
 import { schedule } from "../../src/commands/schedule";
@@ -52,7 +52,7 @@ describe("schedule command", () => {
     const scheduleJobSpy = spy();
 
     const services: unknown = {
-      scheduler: { schedule: scheduleJobSpy },
+      scheduler: { schedule: scheduleJobSpy, has: fake.returns(false) },
     };
 
     const resetSpies = () => {
@@ -64,6 +64,7 @@ describe("schedule command", () => {
 
     it("should not allow incorrect day argument", async () => {
       const args: Record<string, string> = {
+        name: "test",
         day: "Wrong",
         time: "01:20",
         channelStr: "test",
@@ -75,13 +76,14 @@ describe("schedule command", () => {
 
     it("should call scheduleJob with correct arguments", async () => {
       const args: Record<string, string> = {
+        name: "test",
         day: "Thursday",
         time: "01:20",
         channelStr: "test",
         message: "blah blah",
       };
       await schedule.execute({ message: message as Message, args, services } as MatchedCommand);
-      expect(scheduleJobSpy.firstCall.args[0]).to.be.eql({
+      expect(scheduleJobSpy.firstCall.args[1]).to.be.eql({
         minute: "20",
         hour: "01",
         dayOfWeek: 4,
@@ -90,6 +92,7 @@ describe("schedule command", () => {
 
     it("should reject channel that doesn't exist in the guild", async () => {
       const args: Record<string, string> = {
+        name: "test",
         day: "Thursday",
         time: "01:20",
         channelStr: "fake",
@@ -101,6 +104,7 @@ describe("schedule command", () => {
 
     it("should reject guild channel that isn't a text channel", async () => {
       const args: Record<string, string> = {
+        name: "test",
         day: "Thursday",
         time: "01:20",
         channelStr: "wrong",
@@ -112,6 +116,7 @@ describe("schedule command", () => {
 
     it("should reply when successful", async () => {
       const args: Record<string, string> = {
+        name: "test",
         day: "Thursday",
         time: "01:20",
         channelStr: "test",

--- a/test/services/scheduler.spec.ts
+++ b/test/services/scheduler.spec.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { Scheduler } from "../../src/services";
 import { spy, fake } from "sinon";
 import { Client, TextChannel, GuildChannel } from "discord.js";
+import { Job } from "node-schedule";
 
 describe("scheduler service", () => {
   describe("schedule", () => {
@@ -24,7 +25,7 @@ describe("scheduler service", () => {
       const textChannel: unknown = {
         send: fake(),
       };
-      scheduler.schedule(jobParams, { content: "hello" }, textChannel as TextChannel);
+      scheduler.schedule("test", jobParams, { content: "hello" }, textChannel as TextChannel);
       expect(scheduleJobSpy.called).to.be.true;
     });
     it("should successfully resolve when not given a TextChannel", () => {
@@ -33,8 +34,31 @@ describe("scheduler service", () => {
         channel: "test",
         content: "hello",
       };
-      scheduler.schedule(jobParams, messageInfo);
+      scheduler.schedule("test", jobParams, messageInfo);
       expect(scheduleJobSpy.called).to.be.true;
+    });
+  });
+
+  describe("cancel", () => {
+    const scheduler = new Scheduler({} as Client);
+    it("should return false if job doesn't exist", () => {
+      expect(scheduler.cancel("test")).to.be.false;
+    });
+    it("should return true if job exists and call cancel", () => {
+      const cancelSpy = spy();
+      const job: unknown = { cancel: cancelSpy };
+      scheduler.jobStore.set("test", job as Job);
+      expect(scheduler.cancel("test") && cancelSpy.called).to.be.true;
+    });
+  });
+  describe("has", () => {
+    const scheduler = new Scheduler({} as Client);
+    it("return false if no match", () => {
+      expect(scheduler.has("tset")).to.be.false;
+    });
+    scheduler.jobStore.set("test", {} as Job);
+    it("returns true when match found", () => {
+      expect(scheduler.has("test")).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Cancel functionality added to scheduler. To allow for this, schedule command now takes a name parameter which is used as a key to store the job needed to cancel it.