### PR TITLE
Stricter error handling + Command Initialisation

### DIFF
--- a/src/commands/type.ts
+++ b/src/commands/type.ts
@@ -1,4 +1,5 @@
-import type { MatchedCommand } from "../matcher";
+import { Client } from "discord.js";
+import type { MatchedCommand, Services } from "../matcher";
 
 export interface Command {
   readonly name: string;
@@ -6,4 +7,8 @@ export interface Command {
   readonly definition: string;
   readonly help: string;
   execute(command: MatchedCommand): Promise<void>;
+}
+
+export interface CommandWithInit extends Command {
+  init(client: Client, services: Services): Promise<void>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,6 @@ const onError = (err: unknown) => {
   process.exit(1);
 };
 
-// Do we want to kill the bot on Storage error?
 services.store.onError(onError);
 
 client.once("ready", () => {


### PR DESCRIPTION
Uncaught Exceptions and unhandled Promise rejections should cause the node instance to abort, so the PR includes the means to do so. Any error that causes the bot to close unexpectedly is logged with a `!!FATAL!!` annotation, after which the process closes with an exit code of 1 as per the node conventions.

And as an additional feature, including the initialisation concept with Commands, accepting a client and services object in order to process any start-up processes on a `ready` event.