### PR TITLE
Initial cancel command implementation

### DIFF
--- a/src/commands/cancel.ts
+++ b/src/commands/cancel.ts
@@ -1,0 +1,25 @@
+import type { Command } from "./type";
+
+export const cancel: Command = {
+  name: "cancel",
+  description: "Cancels a scheduled message",
+  definition: "cancel :name",
+  help: "use !cancel <name>\n <name> name of the scheduled message you want to cancel",
+  async execute({ message, args, services }): Promise<void> {
+    const { name } = args;
+
+    if (!message.guild) {
+      await message.reply("Must be used in a guild channel");
+      return;
+    }
+
+    if (!services.scheduler.has(name, message.guild.name)) {
+      await message.reply("Job does not exist");
+      return;
+    }
+
+    services.scheduler.cancel(name, message.guild.name);
+    //remove persistance once implemented
+    await message.reply("Job removed");
+  },
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,5 +4,6 @@ import { ping } from "./ping";
 import { help } from "./help";
 import { Command } from "./type";
 import { color } from "./color";
+import { cancel } from "./cancel";
 
-export const commands: Command[] = [schedule, ping, commandsList, color, help];
+export const commands: Command[] = [schedule, ping, commandsList, color, help, cancel];


### PR DESCRIPTION
Cancel command added. For now, just takes a job name and uses the scheduler to cancel it. Once we have persistence implemented, this will also remove the job from that too.