### PR TITLE
Job persistence

### DIFF
--- a/src/commands/cancel.ts
+++ b/src/commands/cancel.ts
@@ -1,4 +1,5 @@
 import type { Command } from "./type";
+import type { StorableJob } from "../services/schedule";
 
 export const cancel: Command = {
   name: "cancel",
@@ -12,6 +13,7 @@ export const cancel: Command = {
       await message.reply("Must be used in a guild channel");
       return;
     }
+    const guildName = message.guild.name;
 
     if (!services.scheduler.has(name, message.guild.name)) {
       await message.reply("Job does not exist");
@@ -20,6 +22,18 @@ export const cancel: Command = {
 
     services.scheduler.cancel(name, message.guild.name);
     //remove persistance once implemented
+    const jobs = await services.store.get<StorableJob[]>("jobs");
+    if (!jobs) {
+      throw new Error("Failed to get jobs from store");
+    }
+
+    const index = jobs.findIndex((job) => job.name === name && job.message.guild === guildName);
+
+    if (index === -1) {
+      throw new Error("Job not found in store array");
+    }
+    jobs.splice(index, 1);
+    await services.store.set("jobs", jobs);
     await message.reply("Job removed");
   },
 };

--- a/src/commands/cancel.ts
+++ b/src/commands/cancel.ts
@@ -21,19 +21,18 @@ export const cancel: Command = {
     }
 
     services.scheduler.cancel(name, message.guild.name);
-    //remove persistance once implemented
+
     const jobs = await services.store.get<StorableJob[]>("jobs");
     if (!jobs) {
       throw new Error("Failed to get jobs from store");
     }
 
-    const index = jobs.findIndex((job) => job.name === name && job.message.guild === guildName);
-
-    if (index === -1) {
-      throw new Error("Job not found in store array");
+    const filteredJobs = jobs.filter((job) => job.name !== name && job.message.guild !== guildName);
+    if (filteredJobs.length === jobs.length) {
+      throw new Error("Job was found in memory but does not exist in the store");
+    } else {
+      await services.store.set("jobs", filteredJobs);
+      await message.reply("Job removed");
     }
-    jobs.splice(index, 1);
-    await services.store.set("jobs", jobs);
-    await message.reply("Job removed");
   },
 };

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -5,5 +5,6 @@ import { help } from "./help";
 import { Command } from "./type";
 import { color } from "./color";
 import { cancel } from "./cancel";
+import { reschedule } from "./reschedule";
 
-export const commands: Command[] = [schedule, ping, commandsList, color, help, cancel];
+export const commands: Command[] = [schedule, ping, commandsList, color, help, cancel, reschedule];

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -5,6 +5,5 @@ import { help } from "./help";
 import { Command } from "./type";
 import { color } from "./color";
 import { cancel } from "./cancel";
-import { reschedule } from "./reschedule";
 
-export const commands: Command[] = [schedule, ping, commandsList, color, help, cancel, reschedule];
+export const commands: Command[] = [schedule, ping, commandsList, color, help, cancel];

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ const services = {
     stdout: process.stdout,
     stderr: createWriteStream("./error.log", { flags: "a" }),
   }),
-  scheduler: new Scheduler(client),
+  scheduler: new Scheduler(),
 };
 
 const eventStream = createMessageStream(

--- a/src/services/schedule.ts
+++ b/src/services/schedule.ts
@@ -1,4 +1,4 @@
-import { Client, TextChannel } from "discord.js";
+import { Client, TextChannel, Message } from "discord.js";
 import { Job, scheduleJob } from "node-schedule";
 import { isTextChannel } from "../commands/helpers/scheduleValidators";
 
@@ -9,45 +9,69 @@ export interface JobParams {
 }
 
 export interface MessageInfo {
-  guild?: string;
-  channel?: string;
+  guild: string;
+  channel: string;
   content: string;
+}
+
+export interface StorableJob {
+  name: string;
+  params: JobParams;
+  message: MessageInfo;
 }
 
 export class Scheduler {
   jobStore = new Map<string, Job>();
   scheduleJob = scheduleJob;
 
-  constructor(private client: Client) {}
+  schedule(name: string, params: JobParams, message: string, target: TextChannel): void {
+    const job = this.scheduleJob(params, () => {
+      void target.send(message);
+    });
+    const guildName = target.guild.name;
+    this.jobStore.set(guildName + name, job);
+  }
 
-  schedule(name: string, params: JobParams, message: MessageInfo, target?: TextChannel): void {
-    let job;
-    let guildName;
-    if (target) {
-      job = this.scheduleJob(params, () => {
-        void target.send(message);
-      });
-      guildName = target.guild.name;
-    } else {
-      const guild = this.client.guilds.cache.find((guild) => guild.name === message.guild);
-      if (!guild) {
-        throw new Error("Guild not found");
-      }
-      const channel = guild.channels.cache.find((channel) => channel.name === message.channel);
-      if (!channel) {
+  scheduleFromStore(storeJob: StorableJob, client: Client): void {
+    const guild = client.guilds.cache.find((guild) => guild.name === storeJob.message.guild);
+    if (!guild) {
+      throw new Error("Guild not found");
+    }
+    const channel = guild.channels.cache.find(
+      (channel) => channel.name === storeJob.message.channel
+    );
+    if (!channel) {
+      throw new Error("Channel not found");
+    }
+
+    if (!isTextChannel(channel)) {
+      throw new Error("Channel found is not a text channel");
+    }
+    const job = this.scheduleJob(storeJob.params, () => {
+      void channel.send(storeJob.message.content);
+    });
+    this.jobStore.set(storeJob.message.guild + storeJob.name, job);
+  }
+
+  scheduleWorkAround(storeJob: StorableJob, message: Message): void {
+    if (storeJob.message.guild === message.guild?.name) {
+      const target = message.guild.channels.cache.find(
+        (channel) => channel.name === storeJob.message.channel
+      );
+
+      if (!target) {
         throw new Error("Channel not found");
       }
 
-      if (!isTextChannel(channel)) {
+      if (!isTextChannel(target)) {
         throw new Error("Channel found is not a text channel");
       }
-      job = this.scheduleJob(params, () => {
-        void channel.send(message.content);
-      });
-      guildName = guild.name;
-    }
 
-    this.jobStore.set(guildName + name, job);
+      const job = this.scheduleJob(storeJob.params, () => {
+        void target.send(storeJob.message.content);
+      });
+      this.jobStore.set(storeJob.message.guild + storeJob.name, job);
+    }
   }
 
   has(name: string, guild: string): boolean {
@@ -58,6 +82,7 @@ export class Scheduler {
     const job = this.jobStore.get(guild + name);
     if (job) {
       job.cancel();
+      this.jobStore.delete(guild + name);
       return true;
     } else {
       return false;

--- a/src/services/schedule.ts
+++ b/src/services/schedule.ts
@@ -1,4 +1,4 @@
-import { Client, TextChannel, Message } from "discord.js";
+import { Client, TextChannel } from "discord.js";
 import { Job, scheduleJob } from "node-schedule";
 import { isTextChannel } from "../commands/helpers/scheduleValidators";
 

--- a/src/services/schedule.ts
+++ b/src/services/schedule.ts
@@ -53,27 +53,6 @@ export class Scheduler {
     this.jobStore.set(storeJob.message.guild + storeJob.name, job);
   }
 
-  scheduleWorkAround(storeJob: StorableJob, message: Message): void {
-    if (storeJob.message.guild === message.guild?.name) {
-      const target = message.guild.channels.cache.find(
-        (channel) => channel.name === storeJob.message.channel
-      );
-
-      if (!target) {
-        throw new Error("Channel not found");
-      }
-
-      if (!isTextChannel(target)) {
-        throw new Error("Channel found is not a text channel");
-      }
-
-      const job = this.scheduleJob(storeJob.params, () => {
-        void target.send(storeJob.message.content);
-      });
-      this.jobStore.set(storeJob.message.guild + storeJob.name, job);
-    }
-  }
-
   has(name: string, guild: string): boolean {
     return this.jobStore.has(guild + name);
   }

--- a/test/commands/cancel.spec.ts
+++ b/test/commands/cancel.spec.ts
@@ -3,15 +3,17 @@ import { cancel } from "../../src/commands/cancel";
 import { Scheduler } from "../../src/services";
 import { MatchedCommand } from "../../src/matcher/types";
 import { fake, spy } from "sinon";
-import { Client, Message } from "discord.js";
+import { Message } from "discord.js";
 import { Job } from "node-schedule";
+import { Store } from "../../src/services";
 
 describe("cancel command", () => {
   describe("execute", () => {
     const replySpy = spy();
     const cancelSpy = spy();
     const services = {
-      scheduler: new Scheduler({} as Client),
+      scheduler: new Scheduler(),
+      store: new Store(),
     };
     services.scheduler.cancel = cancelSpy;
     const args: Record<string, string> = {
@@ -40,6 +42,8 @@ describe("cancel command", () => {
       expect(replySpy.calledWith("Job does not exist")).to.be.true;
     });
     it("successfully call cancel with correct arguments", async () => {
+      const storableJob: unknown = { name: "test", message: { guild: "guild" } };
+      await services.store.set("jobs", [storableJob]);
       const message: unknown = {
         reply: replySpy,
         guild: { name: "guild" },


### PR DESCRIPTION
Job persistence for Scheduler is implemented in this PR. An array of StorableJobs is kept on the store service. The StorableJob object provides information neccessary to recreate the scheduled message without the original Message object and Job object.

A refactor of the Scheduler class was also made to seperate the schedule function into two so that one is used for scheduling from the command and the other is made to schedule from storage as they required different parameters and logically did different things. Storing the client as a property on initialisitation was also removed as the client object is only used when scheduling from the store and now scheduleFromStore takes a parameter of type Client to have the same functionality.

This PR does not contain the fix for closing the process properly.