### PR TITLE
List jobs command

### DIFF
--- a/src/commands/cancel.ts
+++ b/src/commands/cancel.ts
@@ -14,14 +14,14 @@ export const cancel: Command = {
       await message.reply("Must be used in a guild channel");
       return;
     }
-    const guildName = message.guild.name;
+    const guildName = message.guild.id;
 
-    if (!services.scheduler.has(name, message.guild.name)) {
+    if (!services.scheduler.has(name, message.guild.id)) {
       await message.reply("Job does not exist");
       return;
     }
 
-    services.scheduler.cancel(name, message.guild.name);
+    services.scheduler.cancel(name, message.guild.id);
 
     const jobs = await services.store.get<StorableJob[]>("jobs");
     if (!jobs) {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -6,5 +6,15 @@ import { help } from "./help";
 import { color } from "./color";
 import { cancel } from "./cancel";
 import { permission } from "./permission";
+import { jobs } from "./jobs";
 
-export const commands: Command[] = [schedule, ping, commandsList, color, help, cancel, permission];
+export const commands: Command[] = [
+  schedule,
+  ping,
+  commandsList,
+  color,
+  help,
+  cancel,
+  permission,
+  jobs,
+];

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -8,9 +8,14 @@ export const jobs: Command = {
   definition: "jobs",
   help: "use !jobs",
   async execute({ message, services }): Promise<void> {
+    if (!message.guild) {
+      await message.reply("must be used in a guild");
+      return;
+    }
     const jobs = await services.store.get<StorableJob[]>("jobs");
     if (!jobs) throw new Error("StorableJob array missing from store service");
-    const str = jobs.reduce((acc, job) => acc + "\n" + job.name, "");
+    const filteredJobs = jobs.filter((job) => job.message.guild === message.guild?.id);
+    const str = filteredJobs.reduce((acc, job) => acc + "\n" + job.name, "");
     if (str.length === 0) {
       await message.reply("no current jobs");
     } else {

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -1,0 +1,20 @@
+import type { Command } from "./type";
+import type { StorableJob } from "../services/schedule";
+
+export const jobs: Command = {
+  name: "jobs",
+  permission: 1,
+  description: "Lists the jobs that are stored",
+  definition: "jobs",
+  help: "use !jobs",
+  async execute({ message, services }): Promise<void> {
+    const jobs = await services.store.get<StorableJob[]>("jobs");
+    if (!jobs) throw new Error("StorableJob array missing from store service");
+    const str = jobs.reduce((acc, job) => acc + "\n" + job.name, "");
+    if (str.length === 0) {
+      await message.reply("no current jobs");
+    } else {
+      await message.reply(str);
+    }
+  },
+};

--- a/src/services/schedule.ts
+++ b/src/services/schedule.ts
@@ -33,13 +33,11 @@ export class Scheduler {
   }
 
   scheduleFromStore(storeJob: StorableJob, client: Client): void {
-    const guild = client.guilds.cache.find((guild) => guild.name === storeJob.message.guild);
+    const guild = client.guilds.cache.find((guild) => guild.id === storeJob.message.guild);
     if (!guild) {
       throw new Error("Guild not found");
     }
-    const channel = guild.channels.cache.find(
-      (channel) => channel.name === storeJob.message.channel
-    );
+    const channel = guild.channels.cache.find((channel) => channel.id === storeJob.message.channel);
     if (!channel) {
       throw new Error("Channel not found");
     }

--- a/test/commands/cancel.spec.ts
+++ b/test/commands/cancel.spec.ts
@@ -46,7 +46,7 @@ describe("cancel command", () => {
       await services.store.set("jobs", [storableJob]);
       const message: unknown = {
         reply: replySpy,
-        guild: { name: "guild" },
+        guild: { id: "guild" },
       };
       const job: unknown = { cancel: fake() };
       services.scheduler.jobStore.set("guildtest", job as Job);

--- a/test/commands/jobs.spec.ts
+++ b/test/commands/jobs.spec.ts
@@ -1,0 +1,45 @@
+import { expect } from "chai";
+import { jobs } from "../../src/commands/jobs";
+import { fake, spy } from "sinon";
+import { Store } from "../../src/services";
+import { ExtractedCommand } from "../../src/matcher";
+
+describe("list command", () => {
+  describe("execute", () => {
+    const replySpy = spy();
+    const message: unknown = { reply: replySpy };
+    beforeEach(() => replySpy.resetHistory());
+    it("throw an error if store doesn't return an array", async () => {
+      const storeGetFake = fake.returns(null);
+      const services = {
+        store: new Store(),
+      };
+      services.store.get = storeGetFake;
+      try {
+        await jobs.execute({ message, services } as ExtractedCommand);
+        expect.fail("No error thrown");
+      } catch (err) {
+        const error = err as Error;
+        expect(error.message).to.be.eql("StorableJob array missing from store service");
+      }
+    });
+    it("reply with names of jobs", async () => {
+      const storeGetFake = fake.returns([{ name: "test" }, { name: "passed" }]);
+      const services = {
+        store: new Store(),
+      };
+      services.store.get = storeGetFake;
+      await jobs.execute({ message, services } as ExtractedCommand);
+      expect(replySpy.firstCall.args[0]).to.be.eql("\ntest\npassed");
+    });
+    it("when no jobs, reply reporting so", async () => {
+      const storeGetFake = fake.returns([]);
+      const services = {
+        store: new Store(),
+      };
+      services.store.get = storeGetFake;
+      await jobs.execute({ message, services } as ExtractedCommand);
+      expect(replySpy.firstCall.args[0]).to.be.eql("no current jobs");
+    });
+  });
+});

--- a/test/commands/jobs.spec.ts
+++ b/test/commands/jobs.spec.ts
@@ -4,12 +4,12 @@ import { fake, spy } from "sinon";
 import { Store } from "../../src/services";
 import { ExtractedCommand } from "../../src/matcher";
 
-describe("list command", () => {
+describe("jobs command", () => {
   describe("execute", () => {
     const replySpy = spy();
-    const message: unknown = { reply: replySpy };
     beforeEach(() => replySpy.resetHistory());
     it("throw an error if store doesn't return an array", async () => {
+      const message: unknown = { reply: replySpy, guild: { id: "1" } };
       const storeGetFake = fake.returns(null);
       const services = {
         store: new Store(),
@@ -24,7 +24,11 @@ describe("list command", () => {
       }
     });
     it("reply with names of jobs", async () => {
-      const storeGetFake = fake.returns([{ name: "test" }, { name: "passed" }]);
+      const message: unknown = { reply: replySpy, guild: { id: "1" } };
+      const storeGetFake = fake.returns([
+        { name: "test", message: { guild: "1" } },
+        { name: "passed", message: { guild: "1" } },
+      ]);
       const services = {
         store: new Store(),
       };
@@ -32,7 +36,16 @@ describe("list command", () => {
       await jobs.execute({ message, services } as ExtractedCommand);
       expect(replySpy.firstCall.args[0]).to.be.eql("\ntest\npassed");
     });
+    it("can't be used outside a guild", async () => {
+      const message: unknown = { reply: replySpy };
+      const services = {
+        store: new Store(),
+      };
+      await jobs.execute({ message, services } as ExtractedCommand);
+      expect(replySpy.firstCall.args[0]).to.be.eql("must be used in a guild");
+    });
     it("when no jobs, reply reporting so", async () => {
+      const message: unknown = { reply: replySpy, guild: { id: "1" } };
       const storeGetFake = fake.returns([]);
       const services = {
         store: new Store(),


### PR DESCRIPTION
The jobs command lists the jobs currently active in the bot,, allowing users to know what key to use to cancel that message.

Also includes the fix to check for guild.name. 