### PR TITLE
Permission filtered commands list

### DIFF
--- a/src/commands/commandsList.ts
+++ b/src/commands/commandsList.ts
@@ -1,15 +1,31 @@
+import { PermissionType } from "../constants";
 import type { Command } from "./type";
+
+const formatCommandList = (msg: string, { name, description }: Command) =>
+  `${msg}\`${name}\` - ${description}\n`;
 
 export const commandsList: Command = {
   name: "commands",
   description: "Lists the available commands to the user",
   definition: "commands",
   help: "has no arguments, just use !commands",
-  async execute({ message, commands }): Promise<void> {
-    let response = "available commands are:\n";
-    commands.forEach((command) => {
-      response += `${command.name} - ${command.description}\n`;
-    });
+  async execute({ message, commands, services }): Promise<void> {
+    if (!message.guild || !message.member) {
+      await message.reply("Must be used in a guild channel");
+      return;
+    }
+    const setPermission =
+      services.permissions.getPermission(
+        `${message.guild.id}::${message.author.id}`,
+        PermissionType.USER
+      ) ||
+      services.permissions.getPermission(
+        `${message.guild.id}::${message.member.roles.highest.id}`,
+        PermissionType.ROLE
+      );
+    const response = commands
+      .filter(({ permission = 0 }) => setPermission >= permission)
+      .reduce(formatCommandList, "Commands that are available to you are as follows:\n\n");
     await message.reply(response);
   },
 };

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -8,13 +8,14 @@ export const jobs: Command = {
   definition: "jobs",
   help: "use !jobs",
   async execute({ message, services }): Promise<void> {
-    if (!message.guild) {
+    const { guild } = message;
+    if (!guild) {
       await message.reply("must be used in a guild");
       return;
     }
     const jobs = await services.store.get<StorableJob[]>("jobs");
     if (!jobs) throw new Error("StorableJob array missing from store service");
-    const filteredJobs = jobs.filter((job) => job.message.guild === message.guild?.id);
+    const filteredJobs = jobs.filter((job) => job.message.guild === guild.id);
     const str = filteredJobs.reduce((acc, job) => acc + "\n" + job.name, "");
     if (str.length === 0) {
       await message.reply("no current jobs");

--- a/src/commands/permission.ts
+++ b/src/commands/permission.ts
@@ -2,7 +2,8 @@ import type { Services } from "../index.types";
 import type { CommandWithInit } from "./type";
 import { PermissionLevels, PermissionType, SetPermission } from "../constants";
 import { extractId } from "./helpers/mentions";
-import { MessageMentions } from "discord.js";
+
+const isRole = /<@&\d+>/g;
 
 const enum Modifiers {
   GIVE = "give",
@@ -84,9 +85,7 @@ export const permission: CommandWithInit = {
       await message.reply("You cannot change the permissions of a Guild owner");
       return;
     }
-    const type = MessageMentions.ROLES_PATTERN.test(role)
-      ? PermissionType.ROLE
-      : PermissionType.USER;
+    const type = isRole.test(role) ? PermissionType.ROLE : PermissionType.USER;
     let msg: string;
     switch (modifier) {
       case Modifiers.GIVE:

--- a/test/commands/commands.spec.ts
+++ b/test/commands/commands.spec.ts
@@ -1,8 +1,8 @@
-import { commandsList } from "../../src/commands/commandsList";
 import type { Command } from "../../src/commands/type";
+import type { ExtractedCommand } from "../../src/matcher";
 import { expect } from "chai";
 import { spy } from "sinon";
-import { ExtractedCommand } from "../../src/matcher";
+import { commandsList } from "../../src/commands/commandsList";
 import { PermissionLevels } from "../../src/constants";
 
 const reply = spy();
@@ -22,7 +22,7 @@ const testCases: [
   [
     "will error if used in a non-guild channel",
     {
-      getPermission: () => 0,
+      getPermission: () => PermissionLevels.NORMAL,
     },
     {
       guild: null,
@@ -34,7 +34,7 @@ const testCases: [
   [
     "will error if used with a non-guild member",
     {
-      getPermission: () => 0,
+      getPermission: () => PermissionLevels.NORMAL,
     },
     {
       guild: { id: "1111" },

--- a/test/commands/commands.spec.ts
+++ b/test/commands/commands.spec.ts
@@ -2,39 +2,121 @@ import { commandsList } from "../../src/commands/commandsList";
 import type { Command } from "../../src/commands/type";
 import { expect } from "chai";
 import { spy } from "sinon";
-import { Message } from "discord.js";
 import { ExtractedCommand } from "../../src/matcher";
+import { PermissionLevels } from "../../src/constants";
 
-describe("commands command", () => {
+const reply = spy();
+
+const commands = [
+  { name: "ping", description: "Ping!" } as Command,
+  { name: "commands", description: "Lists the available commands to the user" } as Command,
+  { name: "privileged", description: "A privileged command", permission: 1 } as Command,
+];
+
+const testCases: [
+  string,
+  { getPermission: (key: string) => PermissionLevels },
+  unknown,
+  string
+][] = [
+  [
+    "will error if used in a non-guild channel",
+    {
+      getPermission: () => 0,
+    },
+    {
+      guild: null,
+      member: null,
+      reply,
+    },
+    "Must be used in a guild channel",
+  ],
+  [
+    "will error if used with a non-guild member",
+    {
+      getPermission: () => 0,
+    },
+    {
+      guild: { id: "1111" },
+      member: null,
+      reply,
+    },
+    "Must be used in a guild channel",
+  ],
+  [
+    "will return a list of all commands for a privileged user",
+    {
+      getPermission: () => PermissionLevels.OFFICER,
+    },
+    {
+      author: { id: "1234" },
+      guild: { id: "1111" },
+      member: {
+        roles: {
+          highest: {
+            id: "4321",
+          },
+        },
+      },
+      reply,
+    },
+    "Commands that are available to you are as follows:\n\n`ping` - Ping!\n`commands` - Lists the available commands to the user\n`privileged` - A privileged command\n",
+  ],
+  [
+    "will return a list of all commands for a privileged role",
+    {
+      getPermission: (key: string) =>
+        key === "1111::4321" ? PermissionLevels.OFFICER : PermissionLevels.NORMAL,
+    },
+    {
+      author: { id: "1234" },
+      guild: { id: "1111" },
+      member: {
+        roles: {
+          highest: {
+            id: "4321",
+          },
+        },
+      },
+      reply,
+    },
+    "Commands that are available to you are as follows:\n\n`ping` - Ping!\n`commands` - Lists the available commands to the user\n`privileged` - A privileged command\n",
+  ],
+  [
+    "will return a reduced list of commands for a non-privileged user/role",
+    {
+      getPermission: () => PermissionLevels.NORMAL,
+    },
+    {
+      author: { id: "1234" },
+      guild: { id: "1111" },
+      member: {
+        roles: {
+          highest: {
+            id: "4321",
+          },
+        },
+      },
+      reply,
+    },
+    "Commands that are available to you are as follows:\n\n`ping` - Ping!\n`commands` - Lists the available commands to the user\n",
+  ],
+];
+
+describe("Commands list command", () => {
   describe("execute", () => {
-    const replySpy = spy();
-    const message: unknown = {
-      reply: replySpy,
-    };
+    beforeEach(() => reply.resetHistory());
 
-    const command: unknown = {
-      message: message as Message,
-      commands: [
-        { name: "ping", description: "Ping!" } as Command,
-        { name: "commands", description: "Lists the available commands to the user" } as Command,
-      ],
-    };
-    afterEach(() => replySpy.resetHistory());
-    it("should fire reply after building the string", async () => {
-      await commandsList.execute(command as ExtractedCommand);
-      expect(replySpy.called).to.be.true;
-    });
+    for (const [description, permissions, message, result] of testCases) {
+      const services: unknown = {
+        permissions,
+      };
+      const payload: unknown = { message, commands, services };
 
-    it("should reply with ping name and description", async () => {
-      await commandsList.execute(command as ExtractedCommand);
-      expect(replySpy.firstCall.args[0]).to.be.a("string").that.includes("ping - Ping!");
-    });
-
-    it("should contain itself in the command list", async () => {
-      await commandsList.execute(command as ExtractedCommand);
-      expect(replySpy.firstCall.args[0])
-        .to.be.a("string")
-        .that.includes("commands - Lists the available commands to the user");
-    });
+      it(description, async () => {
+        await commandsList.execute(payload as ExtractedCommand);
+        expect(reply.firstCall.args[0]).to.equal(result);
+      });
+    }
   });
 });


### PR DESCRIPTION
Refactored the commands listing command to only show commands that a user has permissions for. This includes a refactor of the unit tests to handle the extra cases for errors and different permission levels.

Included in the PR is some fixes for the permissions command not detecting roles properly, and also a typing fix for the jobs command, because for whatever reason, the condition used for guarding against a null guild wasn't working there.