### PR TITLE
Guild guard refactor

### DIFF
--- a/src/commands/cancel.ts
+++ b/src/commands/cancel.ts
@@ -10,10 +10,6 @@ export const cancel: Command = {
   async execute({ message, args, services }): Promise<void> {
     const { name } = args;
 
-    if (!message.guild) {
-      await message.reply("Must be used in a guild channel");
-      return;
-    }
     const guildName = message.guild.id;
 
     if (!services.scheduler.has(name, message.guild.id)) {

--- a/src/commands/color.ts
+++ b/src/commands/color.ts
@@ -16,11 +16,6 @@ export const color: Command = {
       return;
     }
 
-    if (!message.guild) {
-      await message.reply("Must be used in a guild channel");
-      return;
-    }
-
     const roles = await message.guild.roles.fetch();
 
     if (!roles) {

--- a/src/commands/commandsList.ts
+++ b/src/commands/commandsList.ts
@@ -10,10 +10,6 @@ export const commandsList: Command = {
   definition: "commands",
   help: "has no arguments, just use !commands",
   async execute({ message, commands, services }): Promise<void> {
-    if (!message.guild || !message.member) {
-      await message.reply("Must be used in a guild channel");
-      return;
-    }
     const setPermission =
       services.permissions.getPermission(
         `${message.guild.id}::${message.author.id}`,

--- a/src/commands/greeting.ts
+++ b/src/commands/greeting.ts
@@ -27,9 +27,6 @@ export const greeting: Command = {
   permission: 1,
   async execute({ message, services, args }) {
     const { modifier, message: greetMsg } = args;
-    if (!message.guild) {
-      throw new Error("Command must be used in a guild");
-    }
     let msg: string;
     switch (modifier) {
       case GreetingModifier.SET:

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -8,12 +8,7 @@ export const jobs: Command = {
   definition: "jobs",
   help: "use !jobs",
   async execute({ message, services }): Promise<void> {
-    const { guild } = message;
-    if (!guild) {
-      await message.reply("must be used in a guild");
-      return;
-    }
-    const jobs = await services.store.get<StorableJob[]>(`jobs::${guild.id}`);
+    const jobs = await services.store.get<StorableJob[]>(`jobs::${message.guild.id}`);
     if (!jobs) throw new Error("StorableJob array missing from store service");
     if (jobs.length > 0) {
       const str = jobs.reduce((acc, job) => acc + "\n" + job.name, "");

--- a/src/commands/permission.ts
+++ b/src/commands/permission.ts
@@ -75,10 +75,6 @@ export const permission: CommandWithInit = {
     await Promise.all(loading);
   },
   async execute({ message, services, args }) {
-    if (!message.guild) {
-      await message.reply("Must be used in a guild channel");
-      return;
-    }
     const { modifier, role } = args;
     const id = extractId(role);
     if (id === message.guild.ownerID) {

--- a/src/guards/guildGuard.ts
+++ b/src/guards/guildGuard.ts
@@ -1,0 +1,5 @@
+import type { Message } from "discord.js";
+import type { GuildMessage } from "../index.types";
+
+export const guildGuard = (message: Message): message is GuildMessage =>
+  !(message.guild == null || message.member == null);

--- a/src/guards/index.ts
+++ b/src/guards/index.ts
@@ -1,4 +1,5 @@
 export * from "./messageGuard";
 export * from "./permissionGuard";
 export * from "./routeGuard";
+export * from "./guildGuard";
 export * from "./types";

--- a/src/guards/messageGuard.ts
+++ b/src/guards/messageGuard.ts
@@ -1,5 +1,4 @@
-import type { Message } from "discord.js";
-import type { Config } from "../index.types";
+import type { Config, GuildMessage } from "../index.types";
 
-export const messageGuard = ({ prefix }: Config) => ({ author, content }: Message): boolean =>
+export const messageGuard = ({ prefix }: Config) => ({ author, content }: GuildMessage): boolean =>
   !author.bot && content.startsWith(prefix);

--- a/src/guards/permissionGuard.ts
+++ b/src/guards/permissionGuard.ts
@@ -6,13 +6,10 @@ export const permissionGuard = ({ permissions }: Services): PermissionGuard => (
   message,
   command,
 }) => {
-  const { author, guild } = message;
+  const { author, guild, member } = message;
   const permissionLevel: AllowablePermission = command.permission ?? PermissionLevels.NORMAL;
-  if (guild) {
-    const userCheck = permissions.getPermission(`${guild.id}::${author.id}`, PermissionType.USER);
-    const roleId = author.presence.member?.roles.highest.id || "";
-    const roleCheck = permissions.getPermission(`${guild.id}::${roleId}`, PermissionType.ROLE);
-    return userCheck + roleCheck >= permissionLevel;
-  }
-  return false;
+  const userCheck = permissions.getPermission(`${guild.id}::${author.id}`, PermissionType.USER);
+  const roleId = member.roles.highest.id;
+  const roleCheck = permissions.getPermission(`${guild.id}::${roleId}`, PermissionType.ROLE);
+  return userCheck + roleCheck >= permissionLevel;
 };

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -1,3 +1,4 @@
+import type { Guild, GuildMember, Message, Presence, User } from "discord.js";
 import type { Logger, Store, Scheduler, Permissions } from "./services";
 
 export interface Config {
@@ -11,4 +12,18 @@ export interface Services {
   readonly log: Logger;
   readonly scheduler: Scheduler;
   readonly permissions: Permissions;
+}
+
+export interface GuildPresence extends Presence {
+  member: GuildMember;
+}
+
+export interface GuildAuthor extends User {
+  presence: GuildPresence;
+}
+
+export interface GuildMessage extends Message {
+  guild: Guild;
+  member: GuildMember;
+  author: GuildAuthor;
 }

--- a/src/matcher/types.ts
+++ b/src/matcher/types.ts
@@ -1,7 +1,6 @@
-import type { Message } from "discord.js";
 import type { Command } from "../commands/type";
 import type { RoutedCommand } from "../router";
-import type { Services } from "../index.types";
+import type { GuildMessage, Services } from "../index.types";
 
 /**
  * Argument Matcher. Takes a message input and yields either
@@ -10,7 +9,7 @@ import type { Services } from "../index.types";
 export type ArgumentExtractor = (command: RoutedCommand) => ExtractedCommand | InvalidCommand;
 
 interface BaseCommand {
-  readonly message: Message;
+  readonly message: GuildMessage;
   readonly services: Services;
 }
 

--- a/src/router/types.ts
+++ b/src/router/types.ts
@@ -1,9 +1,9 @@
-import type { Message } from "discord.js";
 import type { Command } from "../commands/type";
+import { GuildMessage } from "../index.types";
 
 export interface RoutedCommand {
-  message: Message;
+  message: GuildMessage;
   command: Command;
 }
 
-export type CommandRouter = (message: Message) => RoutedCommand | undefined;
+export type CommandRouter = (message: GuildMessage) => RoutedCommand | undefined;

--- a/src/streams/createMessageStream.ts
+++ b/src/streams/createMessageStream.ts
@@ -5,7 +5,7 @@ import { InvalidCommand, ExtractedCommand, createArgumentMatcher } from "../matc
 import { createCommandRouter } from "../router";
 import { fromEventPattern, Observable } from "rxjs";
 import { filter, map } from "rxjs/operators";
-import { routeGuard, messageGuard, permissionGuard } from "../guards";
+import { routeGuard, messageGuard, permissionGuard, guildGuard } from "../guards";
 
 export const createMessageStream = (
   config: Config,
@@ -21,6 +21,7 @@ export const createMessageStream = (
       client.off("message", handler);
     }
   ).pipe(
+    filter(guildGuard),
     filter(messageGuard(config)),
     map(createCommandRouter(config, commands)),
     filter(routeGuard),

--- a/test/commands/cancel.spec.ts
+++ b/test/commands/cancel.spec.ts
@@ -24,15 +24,6 @@ describe("cancel command", () => {
       cancelSpy.resetHistory();
     });
 
-    // it("rejects message with no guild", async () => {
-    //   const message: unknown = {
-    //     reply: replySpy,
-    //     guild: null,
-    //   };
-    //   await cancel.execute({ message: message as Message, args } as ExtractedCommand);
-    //   expect(replySpy.calledWith("Must be used in a guild channel")).to.be.true;
-    // });
-
     it("rejects argument of command that doesnt exist", async () => {
       const message: unknown = {
         reply: replySpy,

--- a/test/commands/cancel.spec.ts
+++ b/test/commands/cancel.spec.ts
@@ -24,21 +24,25 @@ describe("cancel command", () => {
       cancelSpy.resetHistory();
     });
 
-    it("rejects message with no guild", async () => {
-      const message: unknown = {
-        reply: replySpy,
-        guild: null,
-      };
-      await cancel.execute({ message: message as Message, args } as ExtractedCommand);
-      expect(replySpy.calledWith("Must be used in a guild channel")).to.be.true;
-    });
+    // it("rejects message with no guild", async () => {
+    //   const message: unknown = {
+    //     reply: replySpy,
+    //     guild: null,
+    //   };
+    //   await cancel.execute({ message: message as Message, args } as ExtractedCommand);
+    //   expect(replySpy.calledWith("Must be used in a guild channel")).to.be.true;
+    // });
 
     it("rejects argument of command that doesnt exist", async () => {
       const message: unknown = {
         reply: replySpy,
-        guild: { name: "test" },
+        guild: { id: "test" },
       };
-      await cancel.execute({ message: message as Message, args, services } as ExtractedCommand);
+      await cancel.execute({
+        message,
+        args,
+        services,
+      } as ExtractedCommand);
       expect(replySpy.calledWith("Job does not exist")).to.be.true;
     });
     it("successfully call cancel with correct arguments", async () => {

--- a/test/commands/color.spec.ts
+++ b/test/commands/color.spec.ts
@@ -106,16 +106,6 @@ describe("color commands", () => {
       expect(replySpy.firstCall.args[0]).to.be.eql("Invalid hex value");
     });
 
-    it("should reject message not posted in a guild channel", async () => {
-      const args: Record<string, string> = { colorHex: "#000000" };
-      const message: unknown = { reply: replySpy, guild: null };
-      await color.execute({
-        message: message as Message,
-        args,
-      } as ExtractedCommand);
-      expect(replySpy.firstCall.args[0]).to.be.eql("Must be used in a guild channel");
-    });
-
     const cache = new Collection<Snowflake, Role>();
     cache.set(SnowflakeUtil.generate(), { name: "ehawjkhejkhe" } as Role);
     const fetchFake = fake.returns({ cache: cache });

--- a/test/commands/commands.spec.ts
+++ b/test/commands/commands.spec.ts
@@ -20,30 +20,6 @@ const testCases: [
   string
 ][] = [
   [
-    "will error if used in a non-guild channel",
-    {
-      getPermission: () => PermissionLevels.NORMAL,
-    },
-    {
-      guild: null,
-      member: null,
-      reply,
-    },
-    "Must be used in a guild channel",
-  ],
-  [
-    "will error if used with a non-guild member",
-    {
-      getPermission: () => PermissionLevels.NORMAL,
-    },
-    {
-      guild: { id: "1111" },
-      member: null,
-      reply,
-    },
-    "Must be used in a guild channel",
-  ],
-  [
     "will return a list of all commands for a privileged user",
     {
       getPermission: () => PermissionLevels.OFFICER,

--- a/test/commands/greeting.spec.ts
+++ b/test/commands/greeting.spec.ts
@@ -53,24 +53,5 @@ describe("greeting", () => {
         expect(reply.firstCall.args[0]).to.equal(result);
       });
     }
-
-    it("can only be used for guilds", async () => {
-      const message: unknown = {
-        channel: {
-          send: reply,
-        },
-        guild: null,
-      };
-      try {
-        await greeting.execute({
-          message,
-          services,
-          args: { modifier: "set", message: "Should not be set" } as Record<string, string>,
-        } as ExtractedCommand);
-        expect.fail("Should not execute successfully");
-      } catch (error) {
-        expect((error as Error).message).to.equal("Command must be used in a guild");
-      }
-    });
   });
 });

--- a/test/commands/jobs.spec.ts
+++ b/test/commands/jobs.spec.ts
@@ -36,14 +36,6 @@ describe("jobs command", () => {
       await jobs.execute({ message, services } as ExtractedCommand);
       expect(replySpy.firstCall.args[0]).to.be.eql("\ntest\npassed");
     });
-    it("can't be used outside a guild", async () => {
-      const message: unknown = { reply: replySpy };
-      const services = {
-        store: new Store(),
-      };
-      await jobs.execute({ message, services } as ExtractedCommand);
-      expect(replySpy.firstCall.args[0]).to.be.eql("must be used in a guild");
-    });
     it("when no jobs, reply reporting so", async () => {
       const message: unknown = { reply: replySpy, guild: { id: "1" } };
       const storeGetFake = fake.returns([]);

--- a/test/commands/permission.spec.ts
+++ b/test/commands/permission.spec.ts
@@ -112,23 +112,6 @@ describe("Permission command", () => {
         "Permission already granted",
       ],
       [
-        "must be used in a guild channel",
-        {
-          message: {
-            reply,
-            channel: {
-              send: reply,
-            },
-          },
-          services,
-          args: {
-            modifier: "give",
-            role: "<@&113>",
-          },
-        },
-        "Must be used in a guild channel",
-      ],
-      [
         "disallows permissions of guild owners to be modified",
         {
           message: {

--- a/test/router/createCommandRouter.spec.ts
+++ b/test/router/createCommandRouter.spec.ts
@@ -1,7 +1,6 @@
 import { expect } from "chai";
-import type { Message } from "discord.js";
 import type { Command } from "../../src/commands/type";
-import type { Config } from "../../src/index.types";
+import type { Config, GuildMessage } from "../../src/index.types";
 import { createCommandRouter } from "../../src/router";
 
 describe("Routers", () => {
@@ -24,7 +23,7 @@ describe("Routers", () => {
 
     for (const [description, message, result] of tests) {
       it(description, () => {
-        expect(router(message as Message)).to.deep.equal(result);
+        expect(router(message as GuildMessage)).to.deep.equal(result);
       });
     }
   });

--- a/test/streams/createMessageStream.spec.ts
+++ b/test/streams/createMessageStream.spec.ts
@@ -55,18 +55,16 @@ describe("createMessageStream.ts", () => {
         author: {
           bot: false,
           id: "id0",
-          presence: {
-            member: {
-              roles: {
-                highest: {
-                  id: "id3",
-                },
-              },
-            },
-          },
         },
         guild: {
           id: "guild",
+        },
+        member: {
+          roles: {
+            highest: {
+              id: "id3",
+            },
+          },
         },
         content: "!ping me",
       } as unknown;
@@ -109,18 +107,16 @@ describe("createMessageStream.ts", () => {
         author: {
           bot: false,
           id: "id0",
-          presence: {
-            member: {
-              roles: {
-                highest: {
-                  id: "id3",
-                },
-              },
-            },
-          },
         },
         guild: {
           id: "guild",
+        },
+        member: {
+          roles: {
+            highest: {
+              id: "id3",
+            },
+          },
         },
         content: "someone says hi",
       } as unknown;


### PR DESCRIPTION
Introduces guildGuard to remove a lot of unnecessary checks later down the line, along with the enforced invariant expressed as a new type GuildMessage.

Basically, we assume that anything without a guild and a member is not a valid message for commands, and as long as those two fields exist in the message, the form of the message is a valid GuildMessage type.