### PR TITLE
Permission filtered help command

### DIFF
--- a/src/commands/commandsList.ts
+++ b/src/commands/commandsList.ts
@@ -1,4 +1,4 @@
-import { PermissionType } from "../constants";
+import { getCommandsByPermission } from "./helpers/permissions";
 import type { Command } from "./type";
 
 const formatCommandList = (msg: string, { name, description }: Command) =>
@@ -9,19 +9,12 @@ export const commandsList: Command = {
   description: "Lists the available commands to the user",
   definition: "commands",
   help: "has no arguments, just use !commands",
-  async execute({ message, commands, services }): Promise<void> {
-    const setPermission =
-      services.permissions.getPermission(
-        `${message.guild.id}::${message.author.id}`,
-        PermissionType.USER
-      ) ||
-      services.permissions.getPermission(
-        `${message.guild.id}::${message.member.roles.highest.id}`,
-        PermissionType.ROLE
-      );
-    const response = commands
-      .filter(({ permission = 0 }) => setPermission >= permission)
-      .reduce(formatCommandList, "Commands that are available to you are as follows:\n\n");
-    await message.reply(response);
+  async execute(payload): Promise<void> {
+    const { message } = payload;
+    const list = getCommandsByPermission(payload).reduce(
+      formatCommandList,
+      "Commands that are available to you are as follows:\n\n"
+    );
+    await message.reply(list);
   },
 };

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,3 +1,4 @@
+import { getCommandsByPermission } from "./helpers/permissions";
 import type { Command } from "./type";
 
 export const help: Command = {
@@ -5,12 +6,13 @@ export const help: Command = {
   description: "provides instruction on how to call commands",
   definition: "help :command",
   help: "use !help <>, replacing the brackets with the name of the command",
-  async execute({ message, args, commands }): Promise<void> {
-    const commandName = args["command"];
-    const result = commands.find((command) => command.name === commandName);
+  async execute(payload): Promise<void> {
+    const { message, args } = payload;
+    const { command } = args;
+    const result = getCommandsByPermission(payload).find(({ name }) => name === command);
 
     if (!result) {
-      await message.reply("Command does not exist");
+      await message.reply("Command does not exist or you do not have permission to use it");
     } else {
       await message.reply(result.help);
     }

--- a/src/commands/helpers/permissions.ts
+++ b/src/commands/helpers/permissions.ts
@@ -1,0 +1,21 @@
+import { PermissionType } from "../../constants";
+import type { ReadonlyList } from "../../index.types";
+import type { ExtractedCommand } from "../../matcher";
+import type { Command } from "../type";
+
+export const getCommandsByPermission = ({
+  message,
+  commands,
+  services,
+}: ExtractedCommand): ReadonlyList<Command> => {
+  const setPermission =
+    services.permissions.getPermission(
+      `${message.guild.id}::${message.author.id}`,
+      PermissionType.USER
+    ) ||
+    services.permissions.getPermission(
+      `${message.guild.id}::${message.member.roles.highest.id}`,
+      PermissionType.ROLE
+    );
+  return commands.filter(({ permission = 0 }) => setPermission >= permission);
+};

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -1,6 +1,8 @@
 import type { Guild, GuildMember, Message, Presence, User } from "discord.js";
 import type { Logger, Store, Scheduler, Permissions } from "./services";
 
+export type ReadonlyList<T> = ReadonlyArray<Readonly<T>>;
+
 export interface Config {
   readonly token: string;
   readonly prefix: string;

--- a/src/matcher/types.ts
+++ b/src/matcher/types.ts
@@ -1,6 +1,6 @@
 import type { Command } from "../commands/type";
 import type { RoutedCommand } from "../router";
-import type { GuildMessage, Services } from "../index.types";
+import type { GuildMessage, ReadonlyList, Services } from "../index.types";
 
 /**
  * Argument Matcher. Takes a message input and yields either
@@ -12,8 +12,6 @@ interface BaseCommand {
   readonly message: GuildMessage;
   readonly services: Services;
 }
-
-type ReadonlyList<T> = Readonly<Readonly<T>[]>;
 
 export interface ExtractedCommand extends BaseCommand {
   readonly matched: true;

--- a/test/commands/help.spec.ts
+++ b/test/commands/help.spec.ts
@@ -2,14 +2,25 @@ import { help } from "../../src/commands/help";
 import { spy } from "sinon";
 import { expect } from "chai";
 import type { ExtractedCommand } from "../../src/matcher";
-import type { Command } from "../../src/commands/type";
-import type { Message } from "discord.js";
 
 describe("help command", () => {
   describe("execute", () => {
     const replySpy = spy();
     const message: unknown = {
       reply: replySpy,
+      guild: {
+        id: "1111",
+      },
+      author: {
+        id: "1234",
+      },
+      member: {
+        roles: {
+          highest: {
+            id: "2222",
+          },
+        },
+      },
     };
 
     const helpCommand: unknown = {
@@ -17,22 +28,32 @@ describe("help command", () => {
       help: "help",
     };
 
+    const services = {
+      permissions: {
+        getPermission: () => 0,
+      },
+    };
+
     it("should reject argument that does not match a command name", async () => {
       const ExtractedCommand: unknown = {
-        message: message as Message,
-        commands: [helpCommand as Command],
+        message,
+        commands: [helpCommand],
+        services,
         args: {
           command: "wrong",
         },
       };
       await help.execute(ExtractedCommand as ExtractedCommand);
-      expect(replySpy.lastCall.args[0]).to.be.eql("Command does not exist");
+      expect(replySpy.lastCall.args[0]).to.be.eql(
+        "Command does not exist or you do not have permission to use it"
+      );
     });
 
     it("should reply with help property of command matched", async () => {
       const ExtractedCommand: unknown = {
-        message: message as Message,
-        commands: [helpCommand as Command],
+        message,
+        commands: [helpCommand],
+        services,
         args: {
           command: "ping",
         },

--- a/test/commands/helpers/permissions.spec.ts
+++ b/test/commands/helpers/permissions.spec.ts
@@ -1,0 +1,62 @@
+import { expect } from "chai";
+import { getCommandsByPermission } from "../../../src/commands/helpers/permissions";
+import { Command } from "../../../src/commands/type";
+import { PermissionLevels } from "../../../src/constants";
+import { ExtractedCommand } from "../../../src/matcher";
+
+describe("permission helpers", () => {
+  describe("getCommandsByPermission", () => {
+    const commands: Command[] = [
+      { name: "one", permission: PermissionLevels.OFFICER } as Command,
+      { name: "two" } as Command,
+    ];
+
+    const message: unknown = {
+      guild: {
+        id: "1111",
+      },
+      author: {
+        id: "1234",
+      },
+      member: {
+        roles: {
+          highest: {
+            id: "2222",
+          },
+        },
+      },
+    };
+
+    const testCases: [string, unknown, number][] = [
+      [
+        "should filter by user permission",
+        { permissions: { getPermission: () => PermissionLevels.OFFICER } },
+        2,
+      ],
+      [
+        "should filter by role permission",
+        {
+          permissions: {
+            getPermission: (key: string) =>
+              key === "1111::2222" ? PermissionLevels.OFFICER : PermissionLevels.NORMAL,
+          },
+        },
+        2,
+      ],
+      [
+        "should show a reduced list for normal permission",
+        { permissions: { getPermission: () => PermissionLevels.NORMAL } },
+        1,
+      ],
+    ];
+
+    for (const [description, services, expectedLength] of testCases) {
+      it(description, () => {
+        const payload: unknown = { commands, services, message };
+        expect(getCommandsByPermission(payload as ExtractedCommand)).to.have.lengthOf(
+          expectedLength
+        );
+      });
+    }
+  });
+});


### PR DESCRIPTION
A simple feature, have the help command only offer help to commands that a user has access to. No point in exposing a command's help if they don't have the permission to use it anyway.

Refactored a part of the commands list command to be its own helper function, so to reuse the permission filtering between that command and help. Also moved a helper type to the index.types as it is needed in more than one place.