### PR TITLE
Permissions refactor and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,17 @@ Currently a big WIP, features will be outlined. Soon™.
 ## Installation
 
 Use `pnpm` and install with `pnpm install` for the best experience.
+
+## Production Setup & Usage
+
+When installing in production env, `git clone` the repo specifically for the main branch. Run `pnpm install -P` to install only the needed production dependencies required to compile the bot via `pnpm run build`.
+
+To run the bot in prod, use `pm2`:
+
+- `pm2 start config/ecosystem.config.js` will start the bot.
+- `pm2 reload config/ecosystem.config.js` will restart it.
+- `pm2 stop config/ecosystem.config.js` will stop the bot.
+
+To access logs, use `pm2 logs catjammer`, with `--lines <number>` allowing for getting more of the logs (default is 15 lines), and then `--err` for fetching the error logs, or `--out` for the info logs.
+
+`pm2 flush` for clearing logs.

--- a/config/ecosystem.config.js
+++ b/config/ecosystem.config.js
@@ -3,8 +3,10 @@ module.exports = {
     {
       name: "catjammer",
       script: "dist/index.js",
-      watch: ".",
+      watch: ["dist"],
       watch_delay: 1000,
+      ignore_watch: ["node_modules"],
+      restart_delay: 1000,
       env: {
         NODE_ENV: "production",
       },

--- a/src/commands/helpers/permissions.ts
+++ b/src/commands/helpers/permissions.ts
@@ -1,4 +1,3 @@
-import { PermissionType } from "../../constants";
 import type { ReadonlyList } from "../../index.types";
 import type { ExtractedCommand } from "../../matcher";
 import type { Command } from "../type";
@@ -8,14 +7,6 @@ export const getCommandsByPermission = ({
   commands,
   services,
 }: ExtractedCommand): ReadonlyList<Command> => {
-  const setPermission =
-    services.permissions.getPermission(
-      `${message.guild.id}::${message.author.id}`,
-      PermissionType.USER
-    ) ||
-    services.permissions.getPermission(
-      `${message.guild.id}::${message.member.roles.highest.id}`,
-      PermissionType.ROLE
-    );
-  return commands.filter(({ permission = 0 }) => setPermission >= permission);
+  const userPermission = services.permissions.resolvePermissionLevel(message.member);
+  return commands.filter(({ permission = 0 }) => userPermission >= permission);
 };

--- a/src/guards/permissionGuard.ts
+++ b/src/guards/permissionGuard.ts
@@ -1,15 +1,11 @@
 import type { Services } from "../index.types";
 import type { PermissionGuard } from "./types";
-import { AllowablePermission, PermissionLevels, PermissionType } from "../constants";
+import { PermissionLevels } from "../constants";
 
 export const permissionGuard = ({ permissions }: Services): PermissionGuard => ({
   message,
   command,
 }) => {
-  const { author, guild, member } = message;
-  const permissionLevel: AllowablePermission = command.permission ?? PermissionLevels.NORMAL;
-  const userCheck = permissions.getPermission(`${guild.id}::${author.id}`, PermissionType.USER);
-  const roleId = member.roles.highest.id;
-  const roleCheck = permissions.getPermission(`${guild.id}::${roleId}`, PermissionType.ROLE);
-  return userCheck + roleCheck >= permissionLevel;
+  const commandPermissionLevel = command.permission ?? PermissionLevels.NORMAL;
+  return permissions.resolvePermissionLevel(message.member) >= commandPermissionLevel;
 };

--- a/src/services/permissions.ts
+++ b/src/services/permissions.ts
@@ -1,8 +1,18 @@
+import { GuildMember, Permissions as DiscordPermissions } from "discord.js";
 import { PermissionLevels, SetPermission, PermissionType } from "../constants";
 
+const OFFICER_LEVEL = new DiscordPermissions([
+  "KICK_MEMBERS",
+  "BAN_MEMBERS",
+  "MANAGE_CHANNELS",
+  "MANAGE_GUILD",
+  "MANAGE_MESSAGES",
+  "MANAGE_ROLES",
+]).bitfield;
+
 export class Permissions {
-  private users = new Map<string, SetPermission>();
-  private roles = new Map<string, SetPermission>();
+  private readonly users = new Map<string, SetPermission>();
+  private readonly roles = new Map<string, SetPermission>();
   assignPermission(key: string, level: SetPermission, type: PermissionType): void {
     this[type].set(key, level);
   }
@@ -11,5 +21,14 @@ export class Permissions {
   }
   getPermission(key: string, type: PermissionType): PermissionLevels {
     return this[type].get(key) ?? PermissionLevels.NORMAL;
+  }
+  resolvePermissionLevel(member: GuildMember): PermissionLevels {
+    if (member.hasPermission(OFFICER_LEVEL)) {
+      return PermissionLevels.OFFICER;
+    }
+    const botPerm =
+      this.getPermission(`${member.guild.id}::${member.id}`, PermissionType.USER) ||
+      this.getPermission(`${member.guild.id}::${member.roles.highest.id}`, PermissionType.ROLE);
+    return botPerm;
   }
 }

--- a/test/commands/commands.spec.ts
+++ b/test/commands/commands.spec.ts
@@ -13,36 +13,11 @@ const commands = [
   { name: "privileged", description: "A privileged command", permission: 1 } as Command,
 ];
 
-const testCases: [
-  string,
-  { getPermission: (key: string) => PermissionLevels },
-  unknown,
-  string
-][] = [
+const testCases: [string, unknown, unknown, string][] = [
   [
     "will return a list of all commands for a privileged user",
     {
-      getPermission: () => PermissionLevels.OFFICER,
-    },
-    {
-      author: { id: "1234" },
-      guild: { id: "1111" },
-      member: {
-        roles: {
-          highest: {
-            id: "4321",
-          },
-        },
-      },
-      reply,
-    },
-    "Commands that are available to you are as follows:\n\n`ping` - Ping!\n`commands` - Lists the available commands to the user\n`privileged` - A privileged command\n",
-  ],
-  [
-    "will return a list of all commands for a privileged role",
-    {
-      getPermission: (key: string) =>
-        key === "1111::4321" ? PermissionLevels.OFFICER : PermissionLevels.NORMAL,
+      resolvePermissionLevel: () => PermissionLevels.OFFICER,
     },
     {
       author: { id: "1234" },
@@ -61,7 +36,7 @@ const testCases: [
   [
     "will return a reduced list of commands for a non-privileged user/role",
     {
-      getPermission: () => PermissionLevels.NORMAL,
+      resolvePermissionLevel: () => PermissionLevels.NORMAL,
     },
     {
       author: { id: "1234" },

--- a/test/commands/help.spec.ts
+++ b/test/commands/help.spec.ts
@@ -30,7 +30,7 @@ describe("help command", () => {
 
     const services = {
       permissions: {
-        getPermission: () => 0,
+        resolvePermissionLevel: () => 0,
       },
     };
 

--- a/test/commands/helpers/permissions.spec.ts
+++ b/test/commands/helpers/permissions.spec.ts
@@ -12,13 +12,11 @@ describe("permission helpers", () => {
     ];
 
     const message: unknown = {
-      guild: {
-        id: "1111",
-      },
-      author: {
-        id: "1234",
-      },
       member: {
+        id: "1234",
+        guild: {
+          id: "1111",
+        },
         roles: {
           highest: {
             id: "2222",
@@ -30,22 +28,12 @@ describe("permission helpers", () => {
     const testCases: [string, unknown, number][] = [
       [
         "should filter by user permission",
-        { permissions: { getPermission: () => PermissionLevels.OFFICER } },
-        2,
-      ],
-      [
-        "should filter by role permission",
-        {
-          permissions: {
-            getPermission: (key: string) =>
-              key === "1111::2222" ? PermissionLevels.OFFICER : PermissionLevels.NORMAL,
-          },
-        },
+        { permissions: { resolvePermissionLevel: () => PermissionLevels.OFFICER } },
         2,
       ],
       [
         "should show a reduced list for normal permission",
-        { permissions: { getPermission: () => PermissionLevels.NORMAL } },
+        { permissions: { resolvePermissionLevel: () => PermissionLevels.NORMAL } },
         1,
       ],
     ];

--- a/test/guards.spec.ts
+++ b/test/guards.spec.ts
@@ -44,7 +44,6 @@ describe("guards", () => {
 
   describe("permissionGuard", () => {
     const permissions = new Permissions();
-    permissions.assignPermission("guild::id1", PermissionLevels.OFFICER, PermissionType.ROLE);
     permissions.assignPermission("guild::id2", PermissionLevels.OFFICER, PermissionType.USER);
     permissions.assignPermission("guild::id3", PermissionLevels.BANNED, PermissionType.ROLE);
     permissions.assignPermission("guild::id4", PermissionLevels.BANNED, PermissionType.USER);
@@ -55,18 +54,17 @@ describe("guards", () => {
         "should filter messages from a user without granted permissions",
         {
           message: {
-            author: {
-              id: "id0",
-            },
-            guild: {
-              id: "guild",
-            },
             member: {
+              id: "id0",
+              guild: {
+                id: "guild",
+              },
               roles: {
                 highest: {
-                  id: "id9",
+                  id: "id0",
                 },
               },
+              hasPermission: () => false,
             },
           },
           command: {
@@ -79,18 +77,17 @@ describe("guards", () => {
         "should allow messages from a user with a role containing the right permission",
         {
           message: {
-            author: {
-              id: "id0",
-            },
-            guild: {
-              id: "guild",
-            },
             member: {
+              id: "id0",
+              guild: {
+                id: "guild",
+              },
               roles: {
                 highest: {
-                  id: "id1",
+                  id: "id0",
                 },
               },
+              hasPermission: () => true,
             },
           },
           command: {
@@ -103,18 +100,17 @@ describe("guards", () => {
         "should allow messages from a user with explicit permissions",
         {
           message: {
-            author: {
-              id: "id2",
-            },
-            guild: {
-              id: "guild",
-            },
             member: {
+              id: "id2",
+              guild: {
+                id: "guild",
+              },
               roles: {
                 highest: {
                   id: "id0",
                 },
               },
+              hasPermission: () => true,
             },
           },
           command: {
@@ -127,18 +123,17 @@ describe("guards", () => {
         "should filter messages from a banned user",
         {
           message: {
-            author: {
-              id: "id4",
-            },
-            guild: {
-              id: "guild",
-            },
             member: {
+              id: "id4",
+              guild: {
+                id: "guild",
+              },
               roles: {
                 highest: {
                   id: "id0",
                 },
               },
+              hasPermission: () => false,
             },
           },
           command: {},
@@ -149,18 +144,17 @@ describe("guards", () => {
         "should filter messages from a banned role",
         {
           message: {
-            author: {
-              id: "id0",
-            },
-            guild: {
-              id: "guild",
-            },
             member: {
+              id: "id0",
+              guild: {
+                id: "guild",
+              },
               roles: {
                 highest: {
                   id: "id3",
                 },
               },
+              hasPermission: () => false,
             },
           },
           command: {},

--- a/test/services/permissions.spec.ts
+++ b/test/services/permissions.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { PermissionType } from "../../src/constants";
 import { Permissions } from "../../src/services";
+import { GuildMember, PermissionResolvable, Permissions as DiscordPermissions } from "discord.js";
 
 describe("permissions.ts", () => {
   describe("Permissions Service", () => {
@@ -22,6 +23,81 @@ describe("permissions.ts", () => {
       service.assignPermission("test", 1, PermissionType.ROLE);
       expect(service.removePermission("test", PermissionType.USER)).to.be.true;
       expect(service.removePermission("test", PermissionType.ROLE)).to.be.true;
+    });
+    it("can resolve a permissions level using Discord permissions or manual permissions", () => {
+      const service = new Permissions();
+      const normalUser: unknown = {
+        id: "norm",
+        guild: {
+          id: "test",
+        },
+        roles: {
+          highest: {
+            id: "normal",
+          },
+        },
+        hasPermission: (perm: PermissionResolvable) =>
+          new DiscordPermissions([
+            "SEND_MESSAGES",
+            "ADD_REACTIONS",
+            "CHANGE_NICKNAME",
+            "ADD_REACTIONS",
+          ]).has(perm),
+      };
+      const elevatedUser: unknown = {
+        id: "banned",
+        guild: {
+          id: "test",
+        },
+        roles: {
+          highest: {
+            id: "normal",
+          },
+        },
+        hasPermission: () => (perm: PermissionResolvable) =>
+          new DiscordPermissions([
+            "SEND_MESSAGES",
+            "ADD_REACTIONS",
+            "CHANGE_NICKNAME",
+            "ADD_REACTIONS",
+            "KICK_MEMBERS",
+            "BAN_MEMBERS",
+            "MANAGE_CHANNELS",
+            "MANAGE_GUILD",
+            "MANAGE_MESSAGES",
+            "MANAGE_ROLES",
+          ]).has(perm),
+      };
+      const bannedUser: unknown = {
+        id: "banned",
+        guild: {
+          id: "test",
+        },
+        roles: {
+          highest: {
+            id: "normal",
+          },
+        },
+        hasPermission: () => false,
+      };
+      const bannedRole: unknown = {
+        id: "other",
+        guild: {
+          id: "test",
+        },
+        roles: {
+          highest: {
+            id: "banned",
+          },
+        },
+        hasPermission: () => false,
+      };
+      service.assignPermission("test::banned", -9, PermissionType.USER);
+      service.assignPermission("test::banned", -9, PermissionType.ROLE);
+      expect(service.resolvePermissionLevel(normalUser as GuildMember)).to.equal(0);
+      expect(service.resolvePermissionLevel(elevatedUser as GuildMember)).to.equal(1);
+      expect(service.resolvePermissionLevel(bannedUser as GuildMember)).to.equal(-9);
+      expect(service.resolvePermissionLevel(bannedRole as GuildMember)).to.equal(-9);
     });
   });
 });

--- a/test/streams/createMessageStream.spec.ts
+++ b/test/streams/createMessageStream.spec.ts
@@ -59,11 +59,16 @@ describe("createMessageStream", () => {
         id: "guild",
       },
       member: {
+        id: "id0",
+        guild: {
+          id: "guild",
+        },
         roles: {
           highest: {
             id: "id3",
           },
         },
+        hasPermission: () => true,
       },
       content: "!ping me",
     } as unknown;
@@ -111,11 +116,16 @@ describe("createMessageStream", () => {
         id: "guild",
       },
       member: {
+        id: "id0",
+        guild: {
+          id: "guild",
+        },
         roles: {
           highest: {
             id: "id3",
           },
         },
+        hasPermission: () => true,
       },
       content: "someone says hi",
     } as unknown;


### PR DESCRIPTION
Adding the ability for the Permissions service to resolve whether a user has elevated permissions or not from the Discord permissions, not just from manual permissions. Still allows for manual bans on users/roles, but also prevents officers from banning each other as discord role permissions will always take precedence.

Including a README update for info on running the bot in prod.