### PR TITLE
Colour reactor

### DIFF
--- a/src/handler/handleRoleReaction.ts
+++ b/src/handler/handleRoleReaction.ts
@@ -1,15 +1,24 @@
 import type { RoleReaction, Services } from "../index.types";
 
 export const handleRoleReaction = (services: Services) => async ({
+  reactorType,
   type,
   reaction,
   member,
 }: RoleReaction): Promise<void> => {
   try {
-    if (type === "add") {
-      await services.roleReactor.applyRole(reaction, member);
+    if (reactorType === "group") {
+      if (type === "add") {
+        await services.roleReactor.applyRole(reaction, member);
+      } else {
+        await services.roleReactor.removeRole(reaction, member);
+      }
     } else {
-      await services.roleReactor.removeRole(reaction, member);
+      if (type === "add") {
+        await services.colorReactor.applyRole(reaction, member);
+      } else {
+        await services.colorReactor.removeRole(reaction, member);
+      }
     }
   } catch (e) {
     services.log.error(e);

--- a/src/handler/handleRoleReaction.ts
+++ b/src/handler/handleRoleReaction.ts
@@ -7,18 +7,11 @@ export const handleRoleReaction = (services: Services) => async ({
   member,
 }: RoleReaction): Promise<void> => {
   try {
-    if (reactorType === "group") {
-      if (type === "add") {
-        await services.roleReactor.applyRole(reaction, member);
-      } else {
-        await services.roleReactor.removeRole(reaction, member);
-      }
+    const reactor = reactorType === "group" ? services.roleReactor : services.colorReactor;
+    if (type === "add") {
+      await reactor.applyRole(reaction, member);
     } else {
-      if (type === "add") {
-        await services.colorReactor.applyRole(reaction, member);
-      } else {
-        await services.colorReactor.removeRole(reaction, member);
-      }
+      await reactor.removeRole(reaction, member);
     }
   } catch (e) {
     services.log.error(e);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   createWelcomeStream,
 } from "./streams";
 import { Store, Logger, Scheduler, Permissions, RoleReactor } from "./services";
+import { groupRoles, colorRoles } from "./reactorRoleLists";
 
 const isProduction = process.env.NODE_ENV === "production";
 
@@ -30,7 +31,8 @@ const services: Services = {
   }),
   scheduler: new Scheduler(),
   permissions: new Permissions(),
-  roleReactor: new RoleReactor(),
+  roleReactor: new RoleReactor(groupRoles),
+  colorReactor: new RoleReactor(colorRoles),
 };
 const subscriptions: Subscription[] = [];
 

--- a/src/index.types.ts
+++ b/src/index.types.ts
@@ -15,6 +15,7 @@ export interface Services {
   readonly scheduler: Scheduler;
   readonly permissions: Permissions;
   readonly roleReactor: RoleReactor;
+  readonly colorReactor: RoleReactor;
 }
 
 export interface GuildPresence extends Presence {
@@ -32,6 +33,7 @@ export interface GuildMessage extends Message {
 }
 
 export interface RoleReaction {
+  reactorType: "group" | "color";
   type: "add" | "remove";
   reaction: MessageReaction;
   member: GuildMember;

--- a/src/reactorRoleLists.ts
+++ b/src/reactorRoleLists.ts
@@ -1,0 +1,84 @@
+import { ReactorRole } from "./services/roleReactor";
+
+export const groupRoles: ReactorRole[] = [
+  {
+    emoji: "⚔",
+    data: {
+      name: "M+ DPS",
+    },
+  },
+  {
+    emoji: "🛡",
+    data: {
+      name: "M+ Tank",
+    },
+  },
+  {
+    emoji: "🚑",
+    data: {
+      name: "M+ Healer",
+    },
+  },
+  {
+    emoji: "🔥",
+    data: {
+      name: "BG DPS",
+    },
+  },
+  {
+    emoji: "❤",
+    data: {
+      name: "BG Healer",
+    },
+  },
+  {
+    emoji: "🥇",
+    data: {
+      name: "Arena DPS",
+    },
+  },
+  {
+    emoji: "🥈",
+    data: {
+      name: "Arena Healer",
+    },
+  },
+];
+
+export const colorRoles: ReactorRole[] = [
+  {
+    emoji: "🥈",
+    data: {
+      name: "blue",
+      color: "#003366",
+    },
+  },
+  {
+    emoji: "🚑",
+    data: {
+      name: "pink",
+      color: "#ffc0cb",
+    },
+  },
+  {
+    emoji: "❤",
+    data: {
+      name: "yellow",
+      color: "#ffff00",
+    },
+  },
+  {
+    emoji: "🥇",
+    data: {
+      name: "red",
+      color: "#ff0000",
+    },
+  },
+  {
+    emoji: "🛡",
+    data: {
+      name: "green",
+      color: "#bada55",
+    },
+  },
+];

--- a/src/reactorRoleLists.ts
+++ b/src/reactorRoleLists.ts
@@ -127,7 +127,7 @@ export const colorRoles: ReactorRole[] = [
     emoji: "⚔",
     data: {
       name: "Warrior",
-      color: "#00FF98",
+      color: "#C69B6D	",
     },
   },
 ];

--- a/src/reactorRoleLists.ts
+++ b/src/reactorRoleLists.ts
@@ -47,38 +47,87 @@ export const groupRoles: ReactorRole[] = [
 
 export const colorRoles: ReactorRole[] = [
   {
-    emoji: "🥈",
+    emoji: "👕",
     data: {
-      name: "blue",
-      color: "#003366",
+      name: "Death Knight",
+      color: "#c41e3a",
     },
   },
   {
-    emoji: "🚑",
+    emoji: "😠",
     data: {
-      name: "pink",
-      color: "#ffc0cb",
+      name: "Demon Hunter",
+      color: "#a330c9",
     },
   },
   {
-    emoji: "❤",
+    emoji: "💩",
     data: {
-      name: "yellow",
-      color: "#ffff00",
+      name: "Druid",
+      color: "#FF7C0A	",
     },
   },
   {
-    emoji: "🥇",
+    emoji: "🏹",
     data: {
-      name: "red",
-      color: "#ff0000",
+      name: "Hunter",
+      color: "#AAD372",
+    },
+  },
+  {
+    emoji: "📘",
+    data: {
+      name: "Mage",
+      color: "#3FC7EB	",
+    },
+  },
+  {
+    emoji: "👊",
+    data: {
+      name: "Monk",
+      color: "#00FF98",
     },
   },
   {
     emoji: "🛡",
     data: {
-      name: "green",
-      color: "#bada55",
+      name: "Paladin",
+      color: "#F48CBA	",
+    },
+  },
+  {
+    emoji: "✝",
+    data: {
+      name: "Priest",
+      color: "#FFFFFF	",
+    },
+  },
+  {
+    emoji: "🗡",
+    data: {
+      name: "Rogue",
+      color: "#FFF468",
+    },
+  },
+  {
+    emoji: "🌊",
+    data: {
+      name: "Shaman",
+      color: "#0070DD",
+    },
+  },
+  {
+    emoji: "💀",
+    data: {
+      name: "Warlock",
+      color: "#8788EE",
+    },
+  },
+  {
+    emoji: "⚔",
+    data: {
+      name: "Warrior",
+      color: "#00FF98",
     },
   },
 ];

--- a/src/services/roleReactor.ts
+++ b/src/services/roleReactor.ts
@@ -12,7 +12,7 @@ export interface ReactorRole {
 export class RoleReactor {
   private cachedReactors = new Set<string>();
 
-  constructor(private roleList: ReactorRole[]) {}
+  constructor(private readonly roleList: ReactorRole[]) {}
 
   extractRoleFromEmoji(reaction: MessageReaction): ReactorRole | undefined {
     const emoji = reaction.emoji.toString();

--- a/src/services/roleReactor.ts
+++ b/src/services/roleReactor.ts
@@ -10,12 +10,9 @@ export interface ReactorRole {
 }
 
 export class RoleReactor {
-  private roleList: ReactorRole[];
   private cachedReactors = new Set<string>();
 
-  constructor(roles: ReactorRole[]) {
-    this.roleList = roles;
-  }
+  constructor(private roleList: ReactorRole[]) {}
 
   extractRoleFromEmoji(reaction: MessageReaction): ReactorRole | undefined {
     const emoji = reaction.emoji.toString();

--- a/src/streams/createReactionStream.ts
+++ b/src/streams/createReactionStream.ts
@@ -21,7 +21,18 @@ const reactionHandler = (
     if (guild) {
       try {
         const member = await guild.members.fetch(user.id);
-        handler({ type, reaction, member });
+        handler({ reactorType: "group", type, reaction, member });
+      } catch (e) {
+        services.log.error(e);
+      }
+    }
+  }
+  if (!user.bot && services.colorReactor.has(reaction.message.id)) {
+    const guild = reaction.message.guild;
+    if (guild) {
+      try {
+        const member = await guild.members.fetch(user.id);
+        handler({ reactorType: "color", type, reaction, member });
       } catch (e) {
         services.log.error(e);
       }

--- a/test/handler/handleRoleReaction.spec.ts
+++ b/test/handler/handleRoleReaction.spec.ts
@@ -11,6 +11,10 @@ describe("handleRoleReaction", () => {
       applyRole: applySpy,
       removeRole: removeSpy,
     },
+    colorReactor: {
+      applyRole: applySpy,
+      removeRole: removeSpy,
+    },
   };
   const handler = handleRoleReaction(services as Services);
   beforeEach(() => {
@@ -19,6 +23,7 @@ describe("handleRoleReaction", () => {
   });
   it("should apply a role on a add type reaction", async () => {
     const event: unknown = {
+      reactorType: "group",
       type: "add",
       reaction: {},
       member: {},
@@ -28,6 +33,27 @@ describe("handleRoleReaction", () => {
   });
   it("should remove a role on a remove type reaction", async () => {
     const event: unknown = {
+      reactorType: "group",
+      type: "remove",
+      reaction: {},
+      member: {},
+    };
+    await handler(event as RoleReaction);
+    expect(removeSpy.callCount).to.equal(1);
+  });
+  it("should apply a color role on a add type reaction", async () => {
+    const event: unknown = {
+      reactorType: "color",
+      type: "add",
+      reaction: {},
+      member: {},
+    };
+    await handler(event as RoleReaction);
+    expect(applySpy.callCount).to.equal(1);
+  });
+  it("should remove a color role on a remove type reaction", async () => {
+    const event: unknown = {
+      reactorType: "color",
       type: "remove",
       reaction: {},
       member: {},
@@ -47,6 +73,7 @@ describe("handleRoleReaction", () => {
       },
     };
     const event: unknown = {
+      reactorType: "group",
       type: "add",
       reaction: {},
       member: {},

--- a/test/services/roleReactor.spec.ts
+++ b/test/services/roleReactor.spec.ts
@@ -3,11 +3,12 @@ import type { GuildMember, MessageReaction } from "discord.js";
 import { spy } from "sinon";
 import type { GuildMessage } from "../../src/index.types";
 import { RoleReactor } from "../../src/services";
+import { groupRoles } from "../../src/reactorRoleLists";
 
 describe("RoleReactor", () => {
   describe("Role list formatting", () => {
     it("lists a formatted string of all roles available", () => {
-      const reactor = new RoleReactor();
+      const reactor = new RoleReactor(groupRoles);
       expect(reactor.list("").trim()).to.equal(
         "List of roles available:\n⚔ - M+ DPS\n🛡 - M+ Tank\n🚑 - M+ Healer\n🔥 - BG DPS\n❤ - BG Healer\n🥇 - Arena DPS\n🥈 - Arena Healer"
       );
@@ -15,7 +16,7 @@ describe("RoleReactor", () => {
   });
   describe("Reactor message cache", () => {
     it("implements a Set-like interface for checking for existing reactor messages", () => {
-      const reactor = new RoleReactor();
+      const reactor = new RoleReactor(groupRoles);
       expect(reactor.has("id")).to.be.false;
       reactor.add("id");
       expect(reactor.has("id")).to.be.true;
@@ -28,7 +29,7 @@ describe("RoleReactor", () => {
       const message: unknown = {
         react,
       };
-      const reactor = new RoleReactor();
+      const reactor = new RoleReactor(groupRoles);
       await reactor.setup(message as GuildMessage);
       expect(react.callCount).to.equal(7);
       expect(react.firstCall.firstArg).to.equal("⚔");
@@ -58,7 +59,7 @@ describe("RoleReactor", () => {
         remove: spies.remove,
       },
     };
-    const reactor = new RoleReactor();
+    const reactor = new RoleReactor(groupRoles);
 
     beforeEach(() => {
       spies.add.resetHistory();

--- a/test/streams/createReactionStream.spec.ts
+++ b/test/streams/createReactionStream.spec.ts
@@ -26,6 +26,9 @@ describe("createReactionStream", () => {
     roleReactor: {
       has: (id: string) => id === "test",
     },
+    colorReactor: {
+      has: (id: string) => id === "color",
+    },
   };
 
   const testCases: [string, string, unknown, unknown, [keyof typeof spies, unknown][]][] = [
@@ -82,6 +85,21 @@ describe("createReactionStream", () => {
       [["handler", false]],
     ],
     [
+      "filters out reactions from not from a guild and color type",
+      "messageReactionRemove",
+      {
+        partial: false,
+        message: {
+          id: "color",
+          guild: null,
+        },
+      },
+      {
+        bot: false,
+      },
+      [["handler", false]],
+    ],
+    [
       "filters out reactions that are not from a reactor message",
       "messageReactionRemove",
       {
@@ -125,12 +143,55 @@ describe("createReactionStream", () => {
       ],
     ],
     [
+      "handles errors from a reaction made by a user not from the guild and of color type",
+      "messageReactionRemove",
+      {
+        partial: false,
+        message: {
+          id: "color",
+          guild: {
+            members: {
+              fetch: () => Promise.reject("fail"),
+            },
+          },
+        },
+      },
+      {
+        bot: false,
+        id: "user",
+      },
+      [
+        ["handler", false],
+        ["error", "fail"],
+      ],
+    ],
+    [
       "allows reactions that are from a reactor message",
       "messageReactionAdd",
       {
         partial: false,
         message: {
           id: "test",
+          guild: {
+            members: {
+              fetch: () => Promise.resolve({}),
+            },
+          },
+        },
+      },
+      {
+        bot: false,
+        id: "user",
+      },
+      [["handler", true]],
+    ],
+    [
+      "allows reactions that are from a reactor message of color type",
+      "messageReactionAdd",
+      {
+        partial: false,
+        message: {
+          id: "color",
           guild: {
             members: {
               fetch: () => Promise.resolve({}),


### PR DESCRIPTION
RoleReactor class refactored to accept a list of roles in it's contructor instead of having a static list. Also moved some of the helper functions into the class itself to accomodate this change.

An extra service of colorReactor has been added. This is an instance of RoleReactor using a different set of roles than roleReactor. The role data has been changed and is now defined in the roleReactorList.ts file.

Reactor command now takes a type argument which allows us to distinguish which RoleReactor service to use. The RoleReactor is then passed to the actons list as a new argument to those functions, replacing the references of the RoleReactor service.

The ReactionStream now looks at both reactor services to see if the message that is reacted to exists in either reactor service's cache and will pass the Reaction to which ever one it exists in.

The key used for the store has now has the reactorType ammended to it, allowing us to know which service the stored reaction belongs to, with reactor command init using this to pass the stored reactions to the correct service.

The roles I've chosen for the colorReactor are class based. Reason being, seeing the colours chosen by the people who used the color command, most people gravitated to their class colour. This reactor than can make this easier for users and if people don't want their class colour, they can use the color command.

Due to the key changes, this will break the current reactor stores on the production instance when deployed, will we need to take steps to ensure nothing funky happens?